### PR TITLE
fixed random fails of unit tests for duplicates check

### DIFF
--- a/test/testlizard.py
+++ b/test/testlizard.py
@@ -5,7 +5,6 @@ import unittest
 import sys
 from test.mock import patch, MagicMock
 from lizard import FileAnalyzer, ObjCReader, generate_tokens, CLikeReader, mapFilesToAnalyzer, FunctionInfo, analyze_file
-from random import randint
 
 class Test_generate_tonken(unittest.TestCase):
 
@@ -318,7 +317,7 @@ class Test_Exclude_Patterns(unittest.TestCase):
                                       None,
                                       ['f1.cpp', 'f2.cpp']],)
         file_handle = mock_open.return_value.__enter__.return_value
-        outs = ["int foo(){{haha({param});\n}}".format(param=randint(i, 20)) for i in range(2)]
+        outs = ["int foo(){{haha({param});\n}}".format(param=i) for i in range(2)]
         file_handle.read.side_effect = lambda: outs.pop()
         files = getSourceFiles(["dir"], [], True)
         self.assertEqual(["./f1.cpp", "./f2.cpp"], list(files))


### PR DESCRIPTION
The problem was the use of the randint function in the test case. In some cases the generated numbers were the same (obvious).

The interesting thing is that it also failed on my computer on a clean system in the first run of tests (this may be some kind of bug in python random module), and then I couldn't reproduce it until I started running tests in a bash loop (1000 executions).

Travis link: https://travis-ci.org/gacekjk/lizard/builds/15196511
