### PR TITLE
Add function end line number

### DIFF
--- a/lizard_for_tnsdl.py
+++ b/lizard_for_tnsdl.py
@@ -55,16 +55,16 @@ class SDLReader(LanguageReaderBase):
             return
         if token == 'ENDPROCEDURE' or token == 'ENDPROCESS' or token == 'ENDSTATE':
             self._state = self._GLOBAL
-            self.univeral_code.END_OF_FUNCTION()
+            self.univeral_code.END_OF_FUNCTION(self.current_line)
             return
         if self.start_of_statement:     
             if token == 'STATE': 
                 self._state = self._STATE
-                self.univeral_code.END_OF_FUNCTION()
+                self.univeral_code.END_OF_FUNCTION(self.current_line)
                 return 
             elif token == 'INPUT': 
                 self._state = self._INPUT
-                self.univeral_code.END_OF_FUNCTION()
+                self.univeral_code.END_OF_FUNCTION(self.current_line)
                 return
         condition = self._is_condition(token, self.last_token)
 

--- a/test/testCAndCPP.py
+++ b/test/testCAndCPP.py
@@ -25,7 +25,9 @@ class Test_c_cpp_lizard(unittest.TestCase):
         self.assertEqual("fun", result[0].name)
         self.assertEqual("fun1", result[1].name)
         self.assertEqual(1, result[0].start_line)
+        self.assertEqual(1, result[0].end_line)
         self.assertEqual(2, result[1].start_line)
+        self.assertEqual(2, result[1].end_line)
     
     def test_function_with_content(self):
         result = create_cpp_lizard("int fun(xx oo){int a; a= call(p1,p2);}")
@@ -50,6 +52,8 @@ class Test_c_cpp_lizard(unittest.TestCase):
     def test_nloc2(self):
         result = create_cpp_lizard("int fun(){aa();\n\n\n\nbb();\n\n\n}")
         self.assertEqual(2, result[0].nloc)
+        self.assertEqual(1, result[0].start_line)
+        self.assertEqual(8, result[0].end_line)
     
     def test_one_function_with_question_mark(self):
         result = create_cpp_lizard("int fun(){return (a)?b:c;}")

--- a/test/testOutput.py
+++ b/test/testOutput.py
@@ -44,9 +44,18 @@ class TestWarningOutput(StreamStdoutTestCase):
         fun = FunctionInfo("foo", 100)
         fun.cyclomatic_complexity = 16
         fileStat = FileInformation("FILENAME", 1, [fun])
-        option = Mock(CCN=15)
+        option = Mock(CCN=15, display_fn_end_line = False)
         print_warnings(option, [fileStat])
         self.assertIn("FILENAME:100: warning: foo has 16 CCN and 0 params (0 NLOC, 0 tokens)\n", sys.stdout.stream)
+
+    def test_should_use_clang_format_with_function_end_line_number_for_warning(self):
+        fun = FunctionInfo("foo", 100)
+        fun.end_line = 100
+        fun.cyclomatic_complexity = 16
+        fileStat = FileInformation("FILENAME", 1, [fun])
+        option = Mock(CCN=15, display_fn_end_line = True)
+        print_warnings(option, [fileStat])
+        self.assertIn("FILENAME:100-100: warning: foo has 16 CCN and 0 params (0 NLOC, 0 tokens)\n", sys.stdout.stream)
 
 
 class TestFileOutput(StreamStdoutTestCase):


### PR DESCRIPTION
I was automating CCN calculation for changed functions and the easiest way was to also add the function end line to the results.

By default the output is not changed; the option -e/--display_fn_end_line adds the end line number to the output.
