### PR TITLE
Calculate Modified CCN

### DIFF
--- a/test/testApplication.py
+++ b/test/testApplication.py
@@ -53,6 +53,16 @@ class TestOptions(unittest.TestCase):
         void foo() {
         #if
         #endif
+            if(bar)
+            {
+            }
+            switch(bar)
+            {
+              case 0: break;
+              case 1: break;
+              case 2: break;
+              case 3: break;
+            }
         }
         '''
         
@@ -69,15 +79,19 @@ class TestOptions(unittest.TestCase):
         
     def test_with_preprocessor_counted_in_CCN(self):
         self.runApplicationWithArgv(['lizard'])
-        self.assertEqual(2, self.fileInfos[0].function_list[0].cyclomatic_complexity)
+        self.assertEqual(7, self.fileInfos[0].function_list[0].cyclomatic_complexity)
 
     def test_not_with_preprocessor_counted_in_CCN(self):
         self.runApplicationWithArgv(['lizard', '-P'])
-        self.assertEqual(1, self.fileInfos[0].function_list[0].cyclomatic_complexity)
+        self.assertEqual(6, self.fileInfos[0].function_list[0].cyclomatic_complexity)
         
     def test_using_the_WordCount_plugin(self):
         self.runApplicationWithArgv(['lizard', '-EWordCount'])
         self.assertEqual(1, self.fileInfos[0].wordCount["foo"])
+
+    def test_using_modified_ccn(self):
+        self.runApplicationWithArgv(['lizard', '--modified'])
+        self.assertEqual(4, self.fileInfos[0].function_list[0].cyclomatic_complexity)
 
 
 from lizard import get_whitelist


### PR DESCRIPTION
I was required to calculate modified CCN so I added the support to lizard.

The default behaviour is not changed and all the functions should have no API breaking changes, i.e. after my changes nothing changes unless the code calling changed functions is changed.

The change is in two parts: the first commit refactors options passing to make it easier to add new options affecting LanguageChooser and language readers; and the second commit adds support for the modified CCN (that can be enabled with -m/--modified command line argument).
