### PR TITLE
dependency extension

### DIFF
--- a/lizard_ext/lizarddependencycount.py
+++ b/lizard_ext/lizarddependencycount.py
@@ -1,0 +1,24 @@
+'''
+This is an extension of lizard, that counts the amount of dependencies within the code.
+'''
+
+class LizardExtension(object):
+    FUNCTION_CAPTION = " dep cnt "
+    FUNCTION_INFO_PART = "dependency_count"
+
+    def __call__(self, tokens, reader):
+        next_word_is_a_dependency = False
+        import_list = []
+        for token in tokens:
+            if not hasattr(reader.context.current_function, "dependency_count"):
+                reader.context.current_function.dependency_count = 0
+            
+            if token == "import" or token == "#include": #this accounts for java, c, c++ and python's import
+                next_word_is_a_dependency = True
+            elif next_word_is_a_dependency == True:
+                import_list += [token]
+                next_word_is_a_dependency = False
+
+            if token in import_list:
+                reader.context.current_function.dependency_count += 1
+            yield token

--- a/test/testFunctionDependencyCount.py
+++ b/test/testFunctionDependencyCount.py
@@ -1,0 +1,13 @@
+import unittest
+from .testHelpers import get_cpp_function_list_with_extnesion
+from lizard_ext.lizarddependencycount import LizardExtension as DependencyCounter
+
+class TestFunctionDependencyCount(unittest.TestCase):
+
+    def test_no_return(self):
+        result = get_cpp_function_list_with_extnesion("int fun(){}", DependencyCounter())
+        self.assertEqual(0, result[0].dependency_count)
+
+    def test_import_dependency(self):
+        result = get_cpp_function_list_with_extnesion("import library; int fun(){library.callMethod()}", DependencyCounter())
+        self.assertEqual(1, result[0].dependency_count)


### PR DESCRIPTION
created a basic dependency count extension.

currently, this extension is able to detect import statements and count how many times a function uses the import. this extension will explain to the programmer how dependent a function is or what library / files the function requires.

however, this extension is not finished. for instance, the program can detect "import java.lang.println" but it cannot detect "import java.lang.*". In addition, the programmer may want to know what external libraries are used, but this currently version also displays dependencies between files / local packages. Also, currently only import statements are read properly, because "#include <>" are not passed in as a token.
