### PR TITLE
dependency extension: import_as support for python

### DIFF
--- a/lizard_ext/lizarddependencycount.py
+++ b/lizard_ext/lizarddependencycount.py
@@ -9,27 +9,52 @@ class LizardExtension(object):  # pylint: disable=R0903
     FUNCTION_INFO_PART = "dependency_count"
 
     def __call__(self, tokens, reader):
-        dependency_type = {'import': 1, '#include': 2}
-        next_word_is_a_dependency = 0
+        ignored_list = {','}
+        dependency_type = {
+            'null': 0,
+            '#include': 1,
+            'import': 2,
+            'python_import_as_change': 3}
+        expect_dependency = 0
         import_list = []
+        import_as_list = []
+        import_as_counter = 0
         for token in tokens:
+            print import_list
             if not hasattr(reader.context.current_function,
                            "dependency_count"):
                 reader.context.current_function.dependency_count = 0
             # this accounts for java, c, c++ and python's import
             if token == "import" or token == "#include":
-                next_word_is_a_dependency = dependency_type[token]
-            elif next_word_is_a_dependency == dependency_type['import']:
-                import_list += [token]
-                next_word_is_a_dependency = 0
-            elif next_word_is_a_dependency == dependency_type['#include']:
-                #gets rid of the <> or "" as well as the .h
+                if import_as_list != []:
+                    import_list.append(import_as_list)
+                expect_dependency = dependency_type[token]
+            elif expect_dependency == dependency_type['#include']:
+                # gets rid of the <> or "" as well as the .h
                 if len(token) >= 4:
                     import_list += [token[1:len(token) - 3]]
                 else:
                     import_list += [token[1:len(token) - 1]]
-                next_word_is_a_dependency = 0
-
+                expect_dependency = dependency_type['null']
+            elif expect_dependency == dependency_type['import']:
+                if token == "as":
+                    expect_dependency = dependency_type[
+                        'python_import_as_change']
+                    import_as_counter = len(import_as_list)
+                    import_as_list = []
+                elif import_as_counter > 4:
+                    import_list += [import_as_list[0]]
+                    import_as_list = []
+                    import_as_counter = 0
+                    expect_dependency = dependency_type['null']
+                elif token not in ignored_list:
+                    import_as_counter += 1
+                    import_as_list += [token]
+            elif expect_dependency == dependency_type['python_import_as_change'] and token not in ignored_list:
+                import_as_counter -= 1
+                import_list += [token]
+                if import_as_counter == 0:
+                    expect_dependency = dependency_type['null']
             if token in import_list:
                 reader.context.current_function.dependency_count += 1
             yield token

--- a/test/testFunctionDependencyCount.py
+++ b/test/testFunctionDependencyCount.py
@@ -2,12 +2,31 @@ import unittest
 from .testHelpers import get_cpp_function_list_with_extnesion
 from lizard_ext.lizarddependencycount import LizardExtension as DependencyCounter
 
+
 class TestFunctionDependencyCount(unittest.TestCase):
 
     def test_no_return(self):
-        result = get_cpp_function_list_with_extnesion("int fun(){}", DependencyCounter())
+        result = get_cpp_function_list_with_extnesion(
+            "int fun(){}",
+            DependencyCounter())
         self.assertEqual(0, result[0].dependency_count)
 
     def test_import_dependency(self):
-        result = get_cpp_function_list_with_extnesion("import library; int fun(){library.callMethod()}", DependencyCounter())
+        result = get_cpp_function_list_with_extnesion(
+            "import library; int fun(){library.callMethod()}",
+            DependencyCounter())
         self.assertEqual(1, result[0].dependency_count)
+
+    def test_python_import_as(self):
+        result = get_cpp_function_list_with_extnesion(
+            "import python as py; int fun(){py.callMethod() py.version = 99}",
+            DependencyCounter())
+        self.assertEqual(2, result[0].dependency_count)
+        result = get_cpp_function_list_with_extnesion(
+            "import candy int fun(){candy.callMethod() py.version = 99}",
+            DependencyCounter())
+        self.assertEqual(1, result[0].dependency_count)
+        result = get_cpp_function_list_with_extnesion(
+            "import kok as www import tree, java as monster, coffee import java public class board { private void function() { java += 1; java.tree = green; www.yay(0); teacher.lecture(0); }",
+            DependencyCounter())
+        self.assertEqual(3, result[0].dependency_count)


### PR DESCRIPTION
created support for dependency in the style of: import _____ as ______. 

introduced more complexity in the lizard extension code that looks for "as".
the current code assumes that a programmer does not use more than 5 dependency in one line in the form of import dep1, dep2, dep3, dep4, dept5 as lib1, lib2, lib3, lib4, lib5. (may be a problem in edge cases)

in addition, I created a simple parser for the #include style dependency. however, this by no means makes the #include fully functional yet (which I intend to work on next)

*passed pep8 test
