### PR TITLE
Processing with C++11 'noexcept' keyword

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -509,7 +509,7 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
         self.context.add_to_long_function_name(" " + token)
 
     def _state_dec_to_imp(self, token):
-        if token == 'const':
+        if token == 'const' or token == 'noexcept':
             self.context.add_to_long_function_name(" " + token)
         elif token == 'throw':
             self._state = self._state_throw

--- a/test/testCAndCPP.py
+++ b/test/testCAndCPP.py
@@ -56,6 +56,10 @@ class Test_c_cpp_lizard(unittest.TestCase):
         result = get_cpp_function_list("""int fun() throw();void foo(){}""")
         self.assertEqual(1, len(result))
 
+    def test_function_dec_with_noexcept(self):
+        result = get_cpp_function_list("int fun() noexcept(true);void foo(){}")
+        self.assertEqual(1, len(result))
+
     def test_function_dec_followed_with_one_word_is_ok(self):
         result = get_cpp_function_list("""int fun() no_throw {}""")
         self.assertEqual(1, len(result))

--- a/test/testCAndCPP.py
+++ b/test/testCAndCPP.py
@@ -112,6 +112,12 @@ class Test_c_cpp_lizard(unittest.TestCase):
         self.assertEqual("abc::fun", result[0].name)
         self.assertEqual("abc::fun( ) const", result[0].long_name)
 
+    def test_one_function_with_noexcept(self):
+        result = get_cpp_function_list("int abc::fun()noexcept{}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("abc::fun", result[0].name)
+        self.assertEqual("abc::fun( ) noexcept", result[0].long_name)
+
     def test_one_function_in_class(self):
         result = get_cpp_function_list("class c {~c(){}}; int d(){}")
         self.assertEqual(2, len(result))
@@ -166,6 +172,11 @@ class Test_c_cpp_lizard(unittest.TestCase):
 
     def test_constructor_initialization_list(self):
         result = get_cpp_function_list('''A::A():a(1){}''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::A", result[0].name)
+
+    def test_constructor_initialization_list_noexcept(self):
+        result = get_cpp_function_list('''A::A()noexcept:a(1){}''')
         self.assertEqual(1, len(result))
         self.assertEqual("A::A", result[0].name)
 


### PR DESCRIPTION
This fix mainly applies to constructors with initialization lists.
The last member variable name is picked up as the name for reporting.