### PR TITLE
Add tests for failing constructor C++11 init list

### DIFF
--- a/test/testCAndCPP.py
+++ b/test/testCAndCPP.py
@@ -169,6 +169,16 @@ class Test_c_cpp_lizard(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual("A::A", result[0].name)
 
+    def test_constructor_initializer_list(self):
+        result = get_cpp_function_list('''A::A():a({1}),value(true){}''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::A", result[0].name)
+
+    def test_constructor_uniform_initialization(self):
+        result = get_cpp_function_list('''A::A():a{1},value(true){}''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::A", result[0].name)
+
     def test_brakets_before_function(self):
         result = get_cpp_function_list('''()''')
         self.assertEqual(0, len(result))


### PR DESCRIPTION
Tests are examples for issue #64.
If a member variable or base class is initialized
with an initializer list or uniform initialization
within the initialization list,
the constructor is parsed as multiple function definition.