### PR TITLE
Hack '~' into C++ destructor names

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -38,7 +38,7 @@ DEFAULT_CCN_THRESHOLD, DEFAULT_WHITELIST, \
 
 def analyze(paths, exclude_pattern=None, threads=1, extensions=None):
     '''
-    returns an iterator of file infomation that contains function
+    returns an iterator of file information that contains function
     statistics.
     '''
     exclude_pattern = exclude_pattern or []
@@ -89,7 +89,7 @@ def create_command_line_parser(prog=None):
     parser.add_argument("-i", "--ignore_warnings",
                         help='''If the number of warnings is equal or less
                         than the number,
-                        the tool will exit normally, otherwize it will generate
+                        the tool will exit normally, otherwise it will generate
                         error. Useful in makefile for legacy code.''',
                         type=int,
                         dest="number",
@@ -97,7 +97,7 @@ def create_command_line_parser(prog=None):
     parser.add_argument("-x", "--exclude",
                         help='''Exclude files that match this pattern. * matches
                         everything,
-                        ? matches any single characoter, "./folder/*" exclude
+                        ? matches any single character, "./folder/*" exclude
                         everything in the folder recursively. Multiple patterns
                         can be specified. Don't forget to add "" around the
                         pattern.''',
@@ -126,7 +126,7 @@ def create_command_line_parser(prog=None):
     parser.add_argument("-E", "--extension",
                         help='''User the extensions. The available extensions
                         are: -Ecpre: it will ignore code in the #else branch.
-                        -Ewordcount: count word fequencies and generate tag
+                        -Ewordcount: count word frequencies and generate tag
                         cloud. -Eoutside: include the global code as one
                         function.
                         ''',
@@ -324,7 +324,7 @@ def recount_switch_case(tokens, reader):
 
 class CodeReader(object):
     '''
-    CodeReaders are used to parse functions structures from code of different
+    CodeReaders are used to parse function structures from code of different
     language. Each language will need a subclass of CodeReader.
     '''
     def __init__(self, context):
@@ -351,9 +351,9 @@ class CodeReader(object):
     @staticmethod
     def generate_tokens(source_code, addition=''):
         def _generate_tokens(source_code, addition):
-            # DONOT put any sub groups in the regex. Good for performance
+            # DO NOT put any sub groups in the regex. Good for performance
             _until_end = r"(?:\\\n|[^\n])*"
-            combined_symbals = ["||", "&&", "===", "!==", "==", "!=", "<=",
+            combined_symbols = ["||", "&&", "===", "!==", "==", "!=", "<=",
                                 ">=",
                                 "<<", ">>>", "++", ">>", "--", '+=', '-=',
                                 '*=', '/=', '^=', '&=', '|=']
@@ -366,7 +366,7 @@ class CodeReader(object):
                 r"|//" + _until_end +
                 r"|\#" +
                 r"|:=|::|\*\*" +
-                r"|" + r"|".join(re.escape(s) for s in combined_symbals) +
+                r"|" + r"|".join(re.escape(s) for s in combined_symbols) +
                 r"|\\\n" +
                 r"|\n" +
                 r"|[^\S\n]+" +
@@ -589,7 +589,7 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
 
 try:
     # lizard.py can run as a stand alone script, without the extensions
-    # The following langauages / extensions will not be supported in
+    # The following languages / extensions will not be supported in
     # stand alone script.
     # pylint: disable=W0611
     from lizard_ext import JavaScriptReader
@@ -694,7 +694,7 @@ def whitelist_filter(warnings, script=None, whitelist=None):
             return open(whitelist, mode='r').read()
         elif whitelist != DEFAULT_WHITELIST:
             print("WARNING: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
-            print("WARNING: the whitelist \""+whitelist+"\" doesn't existing.")
+            print("WARNING: the whitelist \""+whitelist+"\" doesn't exist.")
         return ''
 
     if not script:

--- a/test/testCAndCPP.py
+++ b/test/testCAndCPP.py
@@ -125,7 +125,7 @@ class Test_c_cpp_lizard(unittest.TestCase):
     def test_one_function_in_class(self):
         result = get_cpp_function_list("class c {~c(){}}; int d(){}")
         self.assertEqual(2, len(result))
-        self.assertEqual("c", result[0].name)
+        self.assertEqual("~c", result[0].name)
         self.assertEqual("d", result[1].name)
 
     def test_template_as_reference(self):
@@ -195,6 +195,11 @@ class Test_c_cpp_lizard(unittest.TestCase):
     def test_brakets_before_function(self):
         result = get_cpp_function_list('''()''')
         self.assertEqual(0, len(result))
+
+    def test_destructor_implementation(self):
+        result = get_cpp_function_list('''A::~A(){}''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::~A", result[0].name)
 
     def test_function_that_returns_function_pointers(self):
         result = get_cpp_function_list('''int (*fun())(){}''')


### PR DESCRIPTION
This is a quick and dirty fix.
@terryyin may hack further to find the right way (state, regex?).