### PR TITLE
TTCN-3 language support

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -618,6 +618,20 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
                 self.context.end_of_function()
 
 
+try:
+    # lizard.py can run as a stand alone script, without the extensions
+    # The following languages / extensions will not be supported in
+    # stand alone script.
+    # pylint: disable=W0611
+    from lizard_ext import JavaScriptReader
+    from lizard_ext import PythonReader
+    from lizard_ext import ObjCReader
+    from lizard_ext import TTCNReader
+    from lizard_ext import xml_output
+except ImportError:
+    pass
+
+
 class JavaReader(CLikeReader, CodeReader):
 
     ext = ['java']
@@ -644,20 +658,6 @@ class JavaReader(CLikeReader, CodeReader):
         else:
             self._state = self._state_global
             self._state(token)
-
-
-try:
-    # lizard.py can run as a stand alone script, without the extensions
-    # The following languages / extensions will not be supported in
-    # stand alone script.
-    # pylint: disable=W0611
-    from lizard_ext import JavaScriptReader
-    from lizard_ext import PythonReader
-    from lizard_ext import ObjCReader
-    from lizard_ext import TTCNReader
-    from lizard_ext import xml_output
-except ImportError:
-    pass
 
 
 def token_processor_for_function(tokens, reader):

--- a/lizard.py
+++ b/lizard.py
@@ -618,19 +618,6 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
                 self.context.end_of_function()
 
 
-try:
-    # lizard.py can run as a stand alone script, without the extensions
-    # The following languages / extensions will not be supported in
-    # stand alone script.
-    # pylint: disable=W0611
-    from lizard_ext import JavaScriptReader
-    from lizard_ext import PythonReader
-    from lizard_ext import ObjCReader
-    from lizard_ext import xml_output
-except ImportError:
-    pass
-
-
 class JavaReader(CLikeReader, CodeReader):
 
     ext = ['java']
@@ -657,6 +644,20 @@ class JavaReader(CLikeReader, CodeReader):
         else:
             self._state = self._state_global
             self._state(token)
+
+
+try:
+    # lizard.py can run as a stand alone script, without the extensions
+    # The following languages / extensions will not be supported in
+    # stand alone script.
+    # pylint: disable=W0611
+    from lizard_ext import JavaScriptReader
+    from lizard_ext import PythonReader
+    from lizard_ext import ObjCReader
+    from lizard_ext import TTCNReader
+    from lizard_ext import xml_output
+except ImportError:
+    pass
 
 
 def token_processor_for_function(tokens, reader):

--- a/lizard_ext/__init__.py
+++ b/lizard_ext/__init__.py
@@ -3,4 +3,5 @@
 from .javascript import JavaScriptReader
 from .python import PythonReader
 from .objc import ObjCReader
+from .ttcn import TTCNReader
 from .xmloutput import xml_output

--- a/lizard_ext/ttcn.py
+++ b/lizard_ext/ttcn.py
@@ -63,5 +63,5 @@ class TTCNReader(CLikeReader, CodeReader):
         return CodeReader.generate_tokens(
             source_code,
             r'|' + r'|'.join(re.escape(s) for s in (
-                '..', '->', '<@', '@>', '@lazy', '@fuzzy', '@index', '@deterministic')
-                ))
+                '..', '->', '<@', '@>', '@lazy', '@fuzzy',
+                '@index', '@deterministic')))

--- a/lizard_ext/ttcn.py
+++ b/lizard_ext/ttcn.py
@@ -1,0 +1,67 @@
+''' Language parser for TTCN-3 '''
+
+from lizard import CLikeReader, CodeReader
+import re
+
+
+class TTCNReader(CLikeReader, CodeReader):
+
+    ext = ['ttcn', 'ttcnpp']
+
+    conditions = set(['if', 'else', 'for', 'while', 'altstep',
+                      'case', 'goto', 'alt', 'interleave',
+                      'and', 'or', 'xor'])
+
+    def __init__(self, context):
+        super(TTCNReader, self).__init__(context)
+
+    # module and group blocks are ignored
+    def _state_global(self, token):
+        if token == 'testcase':
+            self._state = self._state_function
+            self.context.start_new_function('__testcase__')
+        elif token == 'function':
+            self._state = self._state_function
+            self.context.start_new_function('')
+        elif token == 'control':
+            self.context.start_new_function('__control__')
+            self._state = self._state_dec_to_imp
+
+    def _state_function(self, token):
+        if token[0].isalpha():
+            self.context.add_to_function_name(token)
+        elif token == '(':
+            self.bracket_stack.append(token)
+            self._state = self._state_dec
+            self.context.add_to_long_function_name(token)
+        elif token == '@deterministic':
+            self.context.add_to_long_function_name(token + ' ')
+        else:
+            self._state = self._state_global
+
+    def _state_dec(self, token):
+        if token == '(':
+            self.bracket_stack.append(token)
+        elif token == ')':
+            self.bracket_stack.pop()
+            if not self.bracket_stack:
+                self._state = self._state_dec_to_imp
+        elif len(self.bracket_stack) == 1:
+            self.context.parameter(token)
+            return
+        self.context.add_to_long_function_name(" " + token)
+
+    def _state_dec_to_imp(self, token):
+        if token == '{':
+            self.br_count += 1
+            self._state = self._state_imp
+        else:
+            self.context.add_to_long_function_name(' ' + token)
+
+    @staticmethod
+    def generate_tokens(source_code, _=None):
+        return CodeReader.generate_tokens(
+            source_code,
+            r'|' + r'|'.join(re.escape(s) for s in (
+                '..', '->', '<@', '@>', '@lazy', '@fuzzy', '@index', '@deterministic')
+                ))

--- a/test/testTTCN.py
+++ b/test/testTTCN.py
@@ -1,0 +1,340 @@
+import unittest
+import inspect
+from lizard import  analyze_file, FileAnalyzer, get_extensions
+
+
+def get_ttcn_function_list(source_code):
+    return analyze_file.analyze_source_code("a.ttcn", source_code).function_list
+
+
+class Test_parser_for_TTCN(unittest.TestCase):
+
+    def test_empty(self):
+        functions = get_ttcn_function_list("")
+        self.assertEqual(0, len(functions))
+
+    def test_no_function(self):
+        result = get_ttcn_function_list("module test {\nconst integer i := 1;\n}")
+        self.assertEqual(0, len(result))
+
+    def test_one_function(self):
+        result = get_ttcn_function_list("module test_one_func {\nfunction fun(){}\n}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+
+    def test_two_function(self):
+        result = get_ttcn_function_list('''
+                module test_two_func {
+                    function fun()
+                    {
+                    }
+                    function fun1()
+                    {
+                    }
+                }
+                ''')
+        self.assertEqual(2, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun1", result[1].name)
+        self.assertEqual(3, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+        self.assertEqual(6, result[1].start_line)
+        self.assertEqual(8, result[1].end_line)
+
+    def test_one_testcase(self):
+        result = get_ttcn_function_list("module test_one_tc {\ntestcase tc(){}\n}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("__testcase__tc", result[0].name)
+
+    def test_two_testcase(self):
+        result = get_ttcn_function_list('''
+                module test_two_tc {
+                    testcase tc()
+                    {
+                    }
+                    testcase tc1()
+                    {
+                    }
+                }
+                ''')
+        self.assertEqual(2, len(result))
+        self.assertEqual("__testcase__tc", result[0].name)
+        self.assertEqual("__testcase__tc1", result[1].name)
+        self.assertEqual(3, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+        self.assertEqual(6, result[1].start_line)
+        self.assertEqual(8, result[1].end_line)
+
+    def test_one_function_one_testcase(self):
+        result = get_ttcn_function_list('''
+                module test_one_func_one_tc {
+                    function fun()
+                    {
+                    }
+                    testcase tc()
+                    {
+                    }
+                }
+                ''')
+        self.assertEqual(2, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("__testcase__tc", result[1].name)
+        self.assertEqual(3, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+        self.assertEqual(6, result[1].start_line)
+        self.assertEqual(8, result[1].end_line)
+
+    def test_function_with_content(self):
+        result = get_ttcn_function_list('''
+                module test_func_w_ctx {
+                    function fun(inout integer i)
+                    {
+                        i := call(i);
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( inout integer i )", result[0].long_name)
+
+    def test_testcase_with_content(self):
+        result = get_ttcn_function_list('''
+                module test_tc_w_ctx {
+                    testcase tc(integer i)
+                    {
+                        i := call(i);
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("__testcase__tc", result[0].name)
+        self.assertEqual("__testcase__tc( integer i )", result[0].long_name)
+
+    def test_function_with_runs_on(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_runs_on {
+                    function fun(inout integer i)
+                    runs on MTC_CT
+                    {
+                        i := call(i);
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( inout integer i ) runs on MTC_CT", result[0].long_name)
+
+    def test_function_with_mtc(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_mtc {
+                    function fun( integer i )
+                    mtc MTC_CT
+                    {
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( integer i ) mtc MTC_CT", result[0].long_name)
+
+    def test_function_with_system(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_system {
+                    function fun( integer i )
+                    system MySystemType
+                    {
+                        var MySystemType v_st := system;
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( integer i ) system MySystemType", result[0].long_name)
+
+    def test_function_with_return(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_return {
+                    function fun( integer i )
+                    return integer
+                    {
+                        return 42;
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( integer i ) return integer", result[0].long_name)
+
+    def test_function_with_return_w_template(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_return_w_template {
+                    function fun( integer i )
+                    return template integer
+                    {
+                        return ?;
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( integer i ) return template integer", result[0].long_name)
+
+    def test_function_in_group(self):
+        result = get_ttcn_function_list('''
+                module test_function_in_group {
+                    group g1 {
+                        function fun( integer i )
+                        {
+                            return 0;
+                        }
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( integer i )", result[0].long_name)
+
+    def test_double_slash_within_string(self):
+        result = get_ttcn_function_list('''
+                module test_double_slash_within_string {
+                    function fun()
+                    {
+                        character a := "\\";
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+
+    def test_function_with_no_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_no_param {
+                    function fun()
+                    return integer
+                    {
+                    }
+                }''')
+        self.assertEqual(0, result[0].parameter_count)
+
+    def test_function_with_1_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_1_param {
+                    function fun(boolean b)
+                    return integer
+                    {
+                        return 1;
+                    }
+                }''')
+        self.assertEqual(1, result[0].parameter_count)
+
+    def test_function_with_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_param {
+                    function fun(integer i := bb * cc, integer j := cc * dd)
+                    return integer
+                    {
+                        return i * j;
+                    }
+                }''')
+        self.assertEqual(2, result[0].parameter_count)
+
+    def test_function_with_strang_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_strang_param {
+                    function fun(boolean b := aa < cc, boolean c := ee < dd)
+                    return boolean
+                    {
+                        return b && c;
+                    }
+                }''')
+        self.assertEqual(2, result[0].parameter_count)
+
+    def test_function_with_template_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_template_param {
+                    function fun(out template boolean b)
+                    {
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( out template boolean b )", result[0].long_name)
+
+    def test_function_with_lazy_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_lazy_param {
+                    function fun(in @lazy integer p_i)
+                    {
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( in @lazy integer p_i )", result[0].long_name)
+
+    def test_function_with_fuzzy_param(self):
+        result = get_ttcn_function_list('''
+                module test_function_with_fuzzy_param {
+                    function fun(in @fuzzy integer p_i)
+                    {
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("fun( in @fuzzy integer p_i )", result[0].long_name)
+
+    def test_function_deterministic(self):
+        result = get_ttcn_function_list('''
+                module test_function_deterministic {
+                    function @deterministic fun()
+                    {
+                    }
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("fun", result[0].name)
+        self.assertEqual("@deterministic fun( )", result[0].long_name)
+
+    def test_brakets_before_function(self):
+        result = get_ttcn_function_list('''module err{\n()\n}''')
+        self.assertEqual(0, len(result))
+
+    def test_underscore(self):
+        result = get_ttcn_function_list('''module err{\nfunction _(){}\n}''')
+        self.assertEqual(0, len(result))
+
+    def test_digits(self):
+        result = get_ttcn_function_list('''module err{\nfunction 42(){}\n}''')
+        self.assertEqual(0, len(result))
+
+    def test_template(self):
+        result = get_ttcn_function_list('''
+                module test_template {
+                    template MyMessageType MyTemplate1 (template ( omit ) integer MyFormalParam):=
+                    {
+                        field1 := MyFormalParam,
+                        field2 := pattern "abc*xyz",
+                        field3 := true
+                    }
+                }''')
+        self.assertEqual(0, len(result))
+
+class Test_Preprocessing(unittest.TestCase):
+
+    def test_content_macro_should_be_ignored(self):
+        result = get_ttcn_function_list('''
+                module test_content_macro_should_be_ignored {
+                    #define MTP_CHEC                    \
+                       function foo () {                     \
+                       }
+                } ''')
+        self.assertEqual(0, len(result))
+
+
+    def test_preprocessors_should_be_ignored_outside_function_implementation(self):
+        result = get_ttcn_function_list('''
+                module test_preprocessors_should_be_ignored_outside_function_implementation {
+                    #ifdef MAGIC
+                    #endif
+                    function foo()
+                    {}
+                } ''')
+        self.assertEqual(1, len(result))
+
+    def test_preprocessor_is_not_function(self):
+        result = get_ttcn_function_list('''
+                module test_preprocessor_is_not_function {
+                    #ifdef A
+                    #elif (defined E)
+                    #endif
+                } ''')
+        self.assertEqual(0, len(result))
+

--- a/test/testTTCN.py
+++ b/test/testTTCN.py
@@ -1,10 +1,11 @@
 import unittest
 import inspect
-from lizard import  analyze_file, FileAnalyzer, get_extensions
+from lizard import analyze_file, FileAnalyzer, get_extensions
 
 
 def get_ttcn_function_list(source_code):
-    return analyze_file.analyze_source_code("a.ttcn", source_code).function_list
+    return analyze_file.analyze_source_code(
+        "a.ttcn", source_code).function_list
 
 
 class Test_parser_for_TTCN(unittest.TestCase):
@@ -14,11 +15,17 @@ class Test_parser_for_TTCN(unittest.TestCase):
         self.assertEqual(0, len(functions))
 
     def test_no_function(self):
-        result = get_ttcn_function_list("module test {\nconst integer i := 1;\n}")
+        result = get_ttcn_function_list('''
+                module test {
+                    const integer i := 1;
+                }''')
         self.assertEqual(0, len(result))
 
     def test_one_function(self):
-        result = get_ttcn_function_list("module test_one_func {\nfunction fun(){}\n}")
+        result = get_ttcn_function_list('''
+                module test_one_func {
+                    function fun() {}
+                }''')
         self.assertEqual(1, len(result))
         self.assertEqual("fun", result[0].name)
 
@@ -42,7 +49,10 @@ class Test_parser_for_TTCN(unittest.TestCase):
         self.assertEqual(8, result[1].end_line)
 
     def test_one_testcase(self):
-        result = get_ttcn_function_list("module test_one_tc {\ntestcase tc(){}\n}")
+        result = get_ttcn_function_list('''
+                module test_one_tc {
+                    testcase tc() {}
+                }''')
         self.assertEqual(1, len(result))
         self.assertEqual("__testcase__tc", result[0].name)
 
@@ -119,7 +129,8 @@ class Test_parser_for_TTCN(unittest.TestCase):
                 }''')
         self.assertEqual(1, len(result))
         self.assertEqual("fun", result[0].name)
-        self.assertEqual("fun( inout integer i ) runs on MTC_CT", result[0].long_name)
+        self.assertEqual("fun( inout integer i ) runs on MTC_CT",
+                         result[0].long_name)
 
     def test_function_with_mtc(self):
         result = get_ttcn_function_list('''
@@ -144,7 +155,8 @@ class Test_parser_for_TTCN(unittest.TestCase):
                 }''')
         self.assertEqual(1, len(result))
         self.assertEqual("fun", result[0].name)
-        self.assertEqual("fun( integer i ) system MySystemType", result[0].long_name)
+        self.assertEqual("fun( integer i ) system MySystemType",
+                         result[0].long_name)
 
     def test_function_with_return(self):
         result = get_ttcn_function_list('''
@@ -157,7 +169,8 @@ class Test_parser_for_TTCN(unittest.TestCase):
                 }''')
         self.assertEqual(1, len(result))
         self.assertEqual("fun", result[0].name)
-        self.assertEqual("fun( integer i ) return integer", result[0].long_name)
+        self.assertEqual("fun( integer i ) return integer",
+                         result[0].long_name)
 
     def test_function_with_return_w_template(self):
         result = get_ttcn_function_list('''
@@ -170,7 +183,8 @@ class Test_parser_for_TTCN(unittest.TestCase):
                 }''')
         self.assertEqual(1, len(result))
         self.assertEqual("fun", result[0].name)
-        self.assertEqual("fun( integer i ) return template integer", result[0].long_name)
+        self.assertEqual("fun( integer i ) return template integer",
+                         result[0].long_name)
 
     def test_function_in_group(self):
         result = get_ttcn_function_list('''
@@ -298,7 +312,9 @@ class Test_parser_for_TTCN(unittest.TestCase):
     def test_template(self):
         result = get_ttcn_function_list('''
                 module test_template {
-                    template MyMessageType MyTemplate1 (template ( omit ) integer MyFormalParam):=
+                    template MyMessageType MyTemplate1 (
+                        template ( omit ) integer MyFormalParam
+                    ):=
                     {
                         field1 := MyFormalParam,
                         field2 := pattern "abc*xyz",
@@ -306,6 +322,7 @@ class Test_parser_for_TTCN(unittest.TestCase):
                     }
                 }''')
         self.assertEqual(0, len(result))
+
 
 class Test_Preprocessing(unittest.TestCase):
 
@@ -318,10 +335,9 @@ class Test_Preprocessing(unittest.TestCase):
                 } ''')
         self.assertEqual(0, len(result))
 
-
-    def test_preprocessors_should_be_ignored_outside_function_implementation(self):
+    def test_preproc_should_be_ignored_outside_func_impl(self):
         result = get_ttcn_function_list('''
-                module test_preprocessors_should_be_ignored_outside_function_implementation {
+                module test_preproc_should_be_ignored_outside_func_impl {
                     #ifdef MAGIC
                     #endif
                     function foo()
@@ -337,4 +353,3 @@ class Test_Preprocessing(unittest.TestCase):
                     #endif
                 } ''')
         self.assertEqual(0, len(result))
-


### PR DESCRIPTION
This adds support for the `TTCN-3` language which is a strongly typed compiled language for conformance testing.
It is imperative and "C-like" with a few special constructs.

In TTCN there is the concept of _testcase_ and _control_ "functions" these special constructs are in lizards output prefixed with `__testcase__` and `__control__` respectively (to be able to distinguish between them and ordinary functions since they are _special_) **please** comment if you want this solved in a any other way.

Sample output:
```
> ~/Development/python-lizard/lizard -V comptest.ttcn
================================================
  NLOC    CCN   token  PARAM  length  location  
------------------------------------------------
       9      1     71      0       9 createconfig@65-74@comptest.ttcn
       3      1     20      0       2 donestop@76-78@comptest.ttcn
       4      3     26      1       3 neg@80-83@comptest.ttcn
      12      3     92      3      13 send_receive@87-100@comptest.ttcn
      24      8    157      3      25 relay_x@150-175@comptest.ttcn
       7      1     59      0       6 __testcase__comptest_1@203-209@comptest.ttcn
       7      1     59      0       6 __testcase__comptest_2@217-223@comptest.ttcn
       7      1     59      0       6 __testcase__comptest_4@249-255@comptest.ttcn
      13      2     96      1      12 __testcase__comptest_5@262-274@comptest.ttcn
      11      1     93      0      11 __testcase__comptest_6@284-295@comptest.ttcn
       8      1     47      0       9 __control__@315-324@comptest.ttcn
--------------------------------------------------------------
1 file analyzed.
==============================================================
NLOC    Avg.NLOC AvgCCN Avg.ttoken  function_cnt    file
--------------------------------------------------------------
    141      9    2.0        70        11     comptest.ttcn

=================================================================
!!!! Warnings (CCN > 15 or arguments > 100 or length > 1000) !!!!
================================================
  NLOC    CCN   token  PARAM  length  location  
------------------------------------------------
==========================================================================================
Total nloc  Avg.nloc  Avg CCN  Avg token  Fun Cnt  Warning cnt   Fun Rt   nloc Rt  
------------------------------------------------------------------------------------------
       141         9     2.09      70.82       11            0      0.00    0.00
``` 

Further reading if interested:
https://en.wikipedia.org/wiki/TTCN-3
http://www.ttcn-3.org/