### PR TITLE
Ignore C++11 unnamed namespace for qualifications

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -414,7 +414,7 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
             self.current = ''
 
         def prefix(self, name):
-            return '::'.join(self.namespace + [name])
+            return '::'.join([x for x in self.namespace if x] + [name])
 
         def __call__(self, token):
             self._state(token)

--- a/test/testCAndCPP.py
+++ b/test/testCAndCPP.py
@@ -210,6 +210,12 @@ class Test_c_cpp_lizard(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual("real::foo", result[0].name)
 
+    def test_nested_unnamed_namespace(self):
+        result = get_cpp_function_list(
+                "namespace real { namespace { bool foo() {} } }")
+        self.assertEqual(1, len(result))
+        self.assertEqual("real::foo", result[0].name)
+
     def test_constructor_initialization_list(self):
         result = get_cpp_function_list('''A::A():a(1){}''')
         self.assertEqual(1, len(result))


### PR DESCRIPTION
Nesting unnamed namespace adds extra ``::`` to the qualification.
```cpp
namespace real { namespace { void foo(int) {...} } }
```
The function is qualified as ``real::::foo`` instead of just ``real::foo``.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/75)
<!-- Reviewable:end -->
