### PR TITLE
Exclude code in C/C++ 'assert' from CCN

### DIFF
--- a/test/testCyclomaticComplexity.py
+++ b/test/testCyclomaticComplexity.py
@@ -37,3 +37,11 @@ class TestCyclomaticComplexity(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual(3, result[0].cyclomatic_complexity)
 
+    def test_exclusion_of_assert(self):
+        result = get_cpp_function_list("void fun() { assert(a && b && c); }")
+        self.assertEqual(1, result[0].cyclomatic_complexity)
+
+    def test_exclusion_of_static_assert(self):
+        result = get_cpp_function_list(
+                "void fun() { static_assert(a && b && c, \"Failed\"); }")
+        self.assertEqual(1, result[0].cyclomatic_complexity)


### PR DESCRIPTION
Consider a simple use case:

```cpp

assert((conditional_expression) && "More description...");

```

This line adds 1 + CCN(conditional_expression)
if the assertion is counted as a part of a function.

Since assertions are mostly used
to check (pre, post)-conditions,
to explicitly state assumptions,
and to catch programmer errors,
they are not expected to be a part of the flow of a function.
Moreover, assertions with side-effects is a very bad idea.
The function should stay the same
if all the assertions are removed (in release mode, for example).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/79)
<!-- Reviewable:end -->
