### PR TITLE
Add test cases for IgnoreAssert extension

### DIFF
--- a/test/testAssertionExtension.py
+++ b/test/testAssertionExtension.py
@@ -11,3 +11,16 @@ class TestAssersionExtension(unittest.TestCase):
         result = get_cpp_function_list_with_extnesion(
                 "void fun() { static_assert(a && b && c, \"Failed\"); }", LizardExtension())
         self.assertEqual(1, result[0].cyclomatic_complexity)
+
+    def test_assert_with_ternary_operator(self):
+        result = get_cpp_function_list_with_extnesion(
+                "void fun() { assert(a ? b : c); }",
+                LizardExtension())
+        self.assertEqual(1, result[0].cyclomatic_complexity)
+
+    def test_ignore_all_code_in_assert(self):
+        result = get_cpp_function_list_with_extnesion(
+                """void fun() { assert(any_of(v.begin(), v.end(),
+                                       [](auto& a) { return a ? b : c })); }""",
+                LizardExtension())
+        self.assertEqual(1, result[0].cyclomatic_complexity)


### PR DESCRIPTION
This is additional tests for handling C/C++ asserts with an extension #79.
The code should ignore complexity of any code inside assert.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/80)
<!-- Reviewable:end -->
