### PR TITLE
Fix C++11 ref qualifiers for functions

### DIFF
--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -235,7 +235,7 @@ class CLikeStates(CodeStateMachine):
         self.context.add_to_long_function_name(token)
 
     def _state_dec_to_imp(self, token):
-        if token == 'const' or token == 'noexcept':
+        if token in ('const', 'noexcept', '&', '&&'):
             self.context.add_to_long_function_name(" " + token)
         elif token == 'throw':
             self._state = self._state_throw

--- a/test/testCyclomaticComplexity.py
+++ b/test/testCyclomaticComplexity.py
@@ -79,3 +79,13 @@ class TestCppCyclomaticComplexity(unittest.TestCase):
         """)
         self.assertEqual(4, result[0].cyclomatic_complexity)
 
+    def test_ref_qualifiers(self):
+        """C++11 rvalue ref qualifiers look like AND operator."""
+        result = get_cpp_function_list(
+                "struct A { void foo() && { return bar() && baz(); } };")
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, result[0].cyclomatic_complexity)
+        result = get_cpp_function_list(
+                "struct A { void foo() const && { return bar() && baz(); } };")
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, result[0].cyclomatic_complexity)

--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -423,6 +423,7 @@ class Test_c_cpp_lizard(unittest.TestCase):
         result = get_cpp_function_list('''int fun(struct a){}''')
         self.assertEqual(1, len(result))
 
+
     def test_trailing_return_type(self):
         """C++11 trailing return type for functions."""
         result = get_cpp_function_list("auto foo() -> void {}")
@@ -431,6 +432,21 @@ class Test_c_cpp_lizard(unittest.TestCase):
         result = get_cpp_function_list("auto foo(int a) -> decltype(a) {}")
         self.assertEqual(1, len(result))
         self.assertEqual("foo", result[0].name)
+
+    def test_ref_qualifiers(self):
+        """C++11 ref qualifiers for member functions."""
+        result = get_cpp_function_list("struct A { void foo() & {} };")
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::foo", result[0].name)
+        result = get_cpp_function_list("struct A { void foo() const & {} };")
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::foo", result[0].name)
+        result = get_cpp_function_list("struct A { void foo() && {} };")
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::foo", result[0].name)
+        result = get_cpp_function_list("struct A { void foo() const && {} };")
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::foo", result[0].name)
 
 
 class Test_Preprocessing(unittest.TestCase):


### PR DESCRIPTION
C++11 ref qualifiers participate in overload resolution
for performance optimization code.
A test for similar looking '&&' operator is also added.

Closes #143 
<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/144)
<!-- Reviewable:end -->
