### PR TITLE
C++11 function trailing return type

### DIFF
--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -239,6 +239,8 @@ class CLikeStates(CodeStateMachine):
             self.context.add_to_long_function_name(" " + token)
         elif token == 'throw':
             self._state = self._state_throw
+        elif token == '->':
+            self._state = self._state_trailing_return
         elif token == '(':
             long_name = self.context.current_function.long_name
             self.try_new_function(long_name)
@@ -257,6 +259,11 @@ class CLikeStates(CodeStateMachine):
     def _state_throw(self, token):
         if token == ')':
             self._state = self._state_dec_to_imp
+
+    @CodeStateMachine.read_until_then(';{')
+    def _state_trailing_return(self, token, _):
+        self._state = self._state_dec_to_imp
+        self._state(token)
 
     def _state_old_c_params(self, token):
         self._saved_tokens.append(token)

--- a/lizard_languages/code_reader.py
+++ b/lizard_languages/code_reader.py
@@ -95,7 +95,7 @@ class CodeReader(object):
             # DO NOT put any sub groups in the regex. Good for performance
             _until_end = r"(?:\\\n|[^\n])*"
             combined_symbols = ["||", "&&", "===", "!==", "==", "!=", "<=",
-                                ">=",
+                                ">=", "->",
                                 "++", "--", '+=', '-=',
                                 '*=', '/=', '^=', '&=', '|=', "..."]
             token_pattern = re.compile(

--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -423,6 +423,15 @@ class Test_c_cpp_lizard(unittest.TestCase):
         result = get_cpp_function_list('''int fun(struct a){}''')
         self.assertEqual(1, len(result))
 
+    def test_trailing_return_type(self):
+        """C++11 trailing return type for functions."""
+        result = get_cpp_function_list("auto foo() -> void {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+        result = get_cpp_function_list("auto foo(int a) -> decltype(a) {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+
 
 class Test_Preprocessing(unittest.TestCase):
 


### PR DESCRIPTION
Trailing return types in C++11 functions
are not registering the function.
The current fix just ignores
whatever is in the trailing return.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/146)
<!-- Reviewable:end -->
