### PR TITLE
Add a test for Nvidia CUDA dialect <<< and >>>

### DIFF
--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -467,3 +467,25 @@ class Test_Big(unittest.TestCase):
         code = "foo<y () >> 5> r;"
         result = get_cpp_function_list(code)
         self.assertEqual(0, len(result))
+
+
+class Test_Dialects(unittest.TestCase):
+
+    def test_cuda_kernel_launch(self):
+        """Special triple < and > for Nvidia CUDA C/C++ code."""
+        result = get_cpp_function_list('''void foo() {
+                kernel <<< gridDim, blockDim, 0 >>> (d_data, height, width);
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+        self.assertEqual(1, result[0].cyclomatic_complexity)
+        result = get_cpp_function_list('''void foo() {
+                kernel <<< gridDim, blockDim, (bar ? 0 : 1) >>> (x, y, z);
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, result[0].cyclomatic_complexity)
+        result = get_cpp_function_list('''void foo() {
+                kernel <<< gridDim, blockDim, 0 >>> (x, y, (bar ? w : z));
+                }''')
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, result[0].cyclomatic_complexity)


### PR DESCRIPTION
The current implementation in Lizard
doesn't recognize these special tokens.
However, the use cases do not affect the complexity metrics,
which is more important than accurate token count.

Originally, Lizard recognized '>>>' token,
but it broke C++11 template code as in PR #68.
The current strategy of ignoring these dialect tokens
seems to be good enough.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/148)
<!-- Reviewable:end -->
