### PR TITLE
Fix error division by zero when running on empty folder.

### DIFF
--- a/lizard_ext/xmloutput.py
+++ b/lizard_ext/xmloutput.py
@@ -87,11 +87,12 @@ def _create_file_measure(doc, result):
     for key, val in summary:
         measure.appendChild(_create_labeled_value_item(doc, 'sum', key, val))
 
-    summary = [("NCSS", file_total_ncss/file_total_funcs),
-               ("CCN", file_total_ccn/file_total_funcs)]
-    for key, val in summary:
-        measure.appendChild(_create_labeled_value_item(
-            doc, 'average', key, val))
+    if file_total_funcs != 0:
+        summary = [("NCSS", file_total_ncss/file_total_funcs),
+                   ("CCN", file_total_ccn/file_total_funcs)]
+        for key, val in summary:
+            measure.appendChild(_create_labeled_value_item(
+                doc, 'average', key, val))
 
     return measure
 

--- a/test/testOutput.py
+++ b/test/testOutput.py
@@ -174,3 +174,9 @@ class TestXMLOutput(unittest.TestCase):
 
     def test_xml_stylesheet(self):
         self.assertIn('''<?xml-stylesheet type="text/xsl" href="https://raw.github.com/terryyin/lizard/master/lizard.xsl"?>''', self.xml)
+
+    def test_xml_output_on_empty_folder(self):
+        xml_empty = xml_output([], True)
+        self.assertIn('''<sum label="NCSS" value="0"/>''', xml_empty)
+        self.assertIn('''<sum label="CCN" value="0"/>''', xml_empty)
+        self.assertIn('''<sum label="Functions" value="0"/>''', xml_empty)


### PR DESCRIPTION
Hi Terry, 
in case when lizard does not find any function in the file or folder it crashes. 
I added a simple condition to check for such scenarios.

Cheers,
Milo