### PR TITLE
Remove warnings from output if no thresholds exceeded

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -24,8 +24,8 @@ C/C++ header files or Java imports. It can deal with
 -  PHP
 -  Scala
 
-By default lizard will search for any source code that it knows an mix
-all the result together. This might not be what you want. You can use
+By default lizard will search for any source code that it knows and mix
+all the results together. This might not be what you want. You can use
 the "-l" option to select language(s).
 
 It counts
@@ -40,7 +40,7 @@ Functions that exceed these limitations will generate warnings. The exit
 code of lizard will be none-Zero if there are warnings.
 
 This tool actually calculates how complex the code 'looks' rather than
-how complex the code real 'is'. People will need this tool because it's
+how complex the code really 'is'. People will need this tool because it's
 often very hard to get all the included folders and files right when
 they are complicated. But we don't really need that kind of accuracy for
 cyclomatic complexity.
@@ -76,7 +76,7 @@ Usage
 
 ::
 
-   lizard [options] [PATH or FILE] [PATH] ... 
+   lizard [options] [PATH or FILE] [PATH] ...
 
 Run for the code under current folder (recursively):
 
@@ -179,7 +179,7 @@ Analyze a folder recursively: lizard mahjong\_game/src
    ======================================
        66     19    247      1    accept_request@64@./httpd.c
    =================================================================================
-   Total NLOC  Avg.NLOC  Avg CCN  Avg token  Fun Cnt  Warning cnt   Fun Rt   NLOC Rt  
+   Total NLOC  Avg.NLOC  Avg CCN  Avg token  Fun Cnt  Warning cnt   Fun Rt   NLOC Rt
    --------------------------------------------------------------------------------
           554        20     4.07      71.15       27            1      0.04    0.12
 

--- a/lizard.py
+++ b/lizard.py
@@ -688,6 +688,13 @@ def print_warnings(option, scheme, warnings):
     return warning_count, warning_nloc
 
 
+def print_no_warnings(option):
+    warn_str = "No thresholds exceeded ({0})".format(
+        ' or '.join("{0} > {1}".format(
+            k, val) for k, val in option.thresholds.items()))
+    print("\n" + "=" * len(warn_str) + "\n" + warn_str)
+
+
 def print_total(warning_count, warning_nloc, saved_result, scheme):
     file_infos = list(file_info for file_info in saved_result if file_info)
     all_fun = list(itertools.chain(*(file_info.function_list
@@ -759,8 +766,14 @@ def get_warnings(code_infos, option):
 
 def print_result(result, option, scheme):
     result = print_and_save_modules(result, option.extensions, scheme)
+    warning_count = 0
+    warning_nloc = 0
     warnings = get_warnings(result, option)
-    warning_count, warning_nloc = print_warnings(option, scheme, warnings)
+    if list(warnings):
+        warnings = get_warnings(result, option)
+        warning_count, warning_nloc = print_warnings(option, scheme, warnings)
+    else:
+        print_no_warnings(option)
     print_total(warning_count, warning_nloc, result, scheme)
     for extension in option.extensions:
         if hasattr(extension, 'print_result'):

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ To install lizard:
 '''
 
 import lizard
-from setuptools import setup, find_packages
+from setuptools import setup
 import os
 
 def install(appname):


### PR DESCRIPTION
The very first time I ran the analyzer I was confused because I saw this big "!!!! Warnings" section with nothing under it. So I removed it. Then I realized that knowing what the thresholds were in your execution is important so I wrote a new print method to give the user that information is a less alarming message. Plus a couple other minor changes to the README.rst and the setup.py files.