### PR TITLE
C++11 Attributes

### DIFF
--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -155,16 +155,25 @@ class CLikeNestingStackStates(CodeStateMachine):
             else:
                 self._state = self.__declare_structure
 
-    @CodeStateMachine.read_until_then(')({;')
+    @CodeStateMachine.read_until_then(')({[;')
     def _read_namespace(self, token, saved):
-        self._state = self._state_global
-        if token == "{":
-            self.context.add_namespace(''.join(itertools.takewhile(
-                lambda x: x not in [":", "final"], saved)))
+        if token == "[":
+            self._state = self._read_attribute
+            self._state(token)
+        else:
+            self._state = self._state_global
+            if token == "{":
+                self.context.add_namespace(''.join(itertools.takewhile(
+                    lambda x: x not in [":", "final"], saved)))
 
     @CodeStateMachine.read_inside_brackets_then("<>", "_state_global")
     def _template_declaration(self, _):
         """Ignores template parameters."""
+        pass
+
+    @CodeStateMachine.read_inside_brackets_then("[]", "_read_namespace")
+    def _read_attribute(self, _):
+        """Ignores C++11 attributes inside [[ ]]."""
         pass
 
 

--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -155,16 +155,21 @@ class CLikeNestingStackStates(CodeStateMachine):
             else:
                 self._state = self.__declare_structure
 
-    @CodeStateMachine.read_until_then(')({[;')
-    def _read_namespace(self, token, saved):
+    def _read_namespace(self, token):
+        """Processes declarations right after namespace/class keywords."""
         if token == "[":
             self._state = self._read_attribute
-            self._state(token)
         else:
-            self._state = self._state_global
-            if token == "{":
-                self.context.add_namespace(''.join(itertools.takewhile(
-                    lambda x: x not in [":", "final"], saved)))
+            self._state = self._read_namespace_name
+        self._state(token)
+
+    @CodeStateMachine.read_until_then(')({;')
+    def _read_namespace_name(self, token, saved):
+        """Processes namespace/class/struct names from declrations."""
+        self._state = self._state_global
+        if token == "{":
+            self.context.add_namespace(''.join(itertools.takewhile(
+                lambda x: x not in [":", "final", "["], saved)))
 
     @CodeStateMachine.read_inside_brackets_then("<>", "_state_global")
     def _template_declaration(self, _):

--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -260,6 +260,9 @@ class CLikeStates(CodeStateMachine):
             self.next(self._state_entering_imp, "{")
         elif token == ":":
             self._state = self._state_initialization_list
+        elif token == "[":
+            self._state = self._state_attribute
+            self._state(token)
         elif not (token[0].isalpha() or token[0] == '_'):
             self._state = self._state_global
             self._state(token)
@@ -329,3 +332,8 @@ class CLikeStates(CodeStateMachine):
     @CodeStateMachine.read_inside_brackets_then("{}")
     def _state_imp(self, _):
         self._state = self._state_global
+
+    @CodeStateMachine.read_inside_brackets_then("[]", "_state_dec_to_imp")
+    def _state_attribute(self, _):
+        "Ignores function attributes with C++11 syntax, i.e., [[ attribute ]]."
+        pass

--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -437,7 +437,6 @@ class Test_c_cpp_lizard(unittest.TestCase):
         result = get_cpp_function_list('''int fun(struct a){}''')
         self.assertEqual(1, len(result))
 
-
     def test_trailing_return_type(self):
         """C++11 trailing return type for functions."""
         result = get_cpp_function_list("auto foo() -> void {}")
@@ -462,6 +461,61 @@ class Test_c_cpp_lizard(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual("A::foo", result[0].name)
 
+
+class Test_cpp11_Attributes(unittest.TestCase):
+    """C++11 extendable attributes can appear pretty much anywhere."""
+
+    def test_namespace(self):
+        result = get_cpp_function_list(
+            "namespace [[visibility(hidden)]] ns { void foo() {} }")
+        self.assertEqual(1, len(result))
+        self.assertEqual("ns::foo", result[0].name)
+
+    def test_class(self):
+        result = get_cpp_function_list(
+            "struct [[alignas(8)]] A { void foo() {} };")
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::foo", result[0].name)
+
+    def test_function_gcc(self):
+        result = get_cpp_function_list(
+            "void foo() __attribute__((noreturn)) {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+
+    def test_function(self):
+        result = get_cpp_function_list("void foo() [[noreturn]] {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+
+    def test_function_parameters(self):
+        result = get_cpp_function_list("void foo(int a [[unused]]) {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+        result = get_cpp_function_list("void foo(int a [[unused]], int b) {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+        result = get_cpp_function_list("void foo(int b, int a [[unused]]) {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+
+    def test_function_return_type(self):
+        result = get_cpp_function_list(
+            "int [[warn_unused_result]] foo(int a) {}")
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+
+    def test_control_structures(self):
+        result = get_cpp_function_list(
+            "int foo() { [[likely(true)]] if (a) return 1; else return 2; }")
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, result[0].cyclomatic_complexity)
+        result = get_cpp_function_list(
+            """int foo() {
+                 for [[omp::parallel()]] (int i{}; i < n; ++i)
+                   sum += i; }""")
+        self.assertEqual(1, len(result))
+        self.assertEqual(2, result[0].cyclomatic_complexity)
 
 class Test_Preprocessing(unittest.TestCase):
 

--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -477,12 +477,6 @@ class Test_cpp11_Attributes(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual("A::foo", result[0].name)
 
-    def test_function_gcc(self):
-        result = get_cpp_function_list(
-            "void foo() __attribute__((noreturn)) {}")
-        self.assertEqual(1, len(result))
-        self.assertEqual("foo", result[0].name)
-
     def test_function(self):
         result = get_cpp_function_list("void foo() [[noreturn]] {}")
         self.assertEqual(1, len(result))

--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -470,10 +470,18 @@ class Test_cpp11_Attributes(unittest.TestCase):
             "namespace [[visibility(hidden)]] ns { void foo() {} }")
         self.assertEqual(1, len(result))
         self.assertEqual("ns::foo", result[0].name)
+        result = get_cpp_function_list(
+            "namespace ns [[deprecated]] { void foo() {} }")
+        self.assertEqual(1, len(result))
+        self.assertEqual("ns::foo", result[0].name)
 
     def test_class(self):
         result = get_cpp_function_list(
             "struct [[alignas(8)]] A { void foo() {} };")
+        self.assertEqual(1, len(result))
+        self.assertEqual("A::foo", result[0].name)
+        result = get_cpp_function_list(
+            "struct A [[deprecated]] { void foo() {} };")
         self.assertEqual(1, len(result))
         self.assertEqual("A::foo", result[0].name)
 
@@ -510,6 +518,7 @@ class Test_cpp11_Attributes(unittest.TestCase):
                    sum += i; }""")
         self.assertEqual(1, len(result))
         self.assertEqual(2, result[0].cyclomatic_complexity)
+
 
 class Test_Preprocessing(unittest.TestCase):
 


### PR DESCRIPTION
Initial support for C++11 [attributes](http://en.cppreference.com/w/cpp/language/attributes).
There's no need to process them for the current Lizard analyses,
so all attributes are ignored.

If attributes are not processed (ignored),
they mess the class/namespace names and confuse the function processing states.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/156)
<!-- Reviewable:end -->
