### PR TITLE
Refactor setup.py script and the installation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ install:
 install:
   - pip install -e .
   - pip install -r dev_requirements.txt
-  - python setup.py install
+  - python setup.py build install
 
 script:
   - make

--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Or if you've got the source:
 
 ::
 
-   [sudo] python setup.py install
+   [sudo] python setup.py build install --install-dir=/path/to/installation/directory/
 
 Usage
 -----

--- a/hfcca
+++ b/hfcca
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-from lizard import lizard_main
-import sys
-
-
-if __name__ == "__main__":
-    lizard_main(sys.argv)

--- a/hfcca.bat
+++ b/hfcca.bat
@@ -1,2 +1,0 @@
-@echo off
-python -m lizard %*

--- a/lizard
+++ b/lizard
@@ -1,7 +1,0 @@
-#!/usr/bin/env python
-from lizard import lizard_main
-import sys
-
-
-if __name__ == "__main__":
-    lizard_main(sys.argv)

--- a/lizard.bat
+++ b/lizard.bat
@@ -1,2 +1,0 @@
-@echo off
-python -m lizard %*

--- a/lizard.py
+++ b/lizard.py
@@ -925,8 +925,13 @@ def get_extensions(extension_names):
 analyze_file = FileAnalyzer(get_extensions([]))  # pylint: disable=C0103
 
 
-def lizard_main(argv):
-    options = parse_args(argv)
+def main(argv=None):
+    """Command-line entrance to Lizard.
+
+    Args:
+        argv: Arguments vector; if None, sys.argv by default.
+    """
+    options = parse_args(argv or sys.argv)
     printer = options.printer or print_result
     schema = OutputScheme(options.extensions)
     if schema.any_silent():
@@ -947,4 +952,4 @@ def lizard_main(argv):
 
 
 if __name__ == "__main__":
-    lizard_main(sys.argv)
+    main()

--- a/profile.py
+++ b/profile.py
@@ -1,4 +1,4 @@
-from lizard import lizard_main
+from lizard import main
 import cProfile, pstats, StringIO
 import sys
 
@@ -6,12 +6,10 @@ import sys
 if __name__ == "__main__":
     pr = cProfile.Profile()
     pr.enable()
-    lizard_main(sys.argv)
+    main()
     pr.disable()
     s = StringIO.StringIO()
     sortby = 'tottime'
     ps = pstats.Stats(pr, stream=s).sort_stats(sortby)
     ps.print_stats()
     print s.getvalue()
-
-

--- a/setup.py
+++ b/setup.py
@@ -1,58 +1,46 @@
+#!/usr/bin/env python
 '''
 Setup script.
 To install lizard:
-[sudo] python setup.py install
+sudo setup.py build install
 '''
 
-import lizard
 from setuptools import setup
-import os
 
-def install(appname):
+import lizard
 
-    try:
-        with open(os.path.join(os.path.dirname(__file__), 'README.rst')) as fobj:
-            readme = fobj.read()
-    except IOError:
-        readme = "lizard"
-
-    setup(
-          name = appname,
-          version = lizard.VERSION,
-          description = ''' A code analyzer without caring the C/C++ header files.
+setup(
+    name='lizard',
+    version=lizard.VERSION,
+    description='''A code analyzer without caring the C/C++ header files.
 It works with Java, C/C++, JavaScript, Python, Ruby, Swift, Objective C. Metrics includes cyclomatic complexity number etc.''',
-          long_description =  readme,
-          url = 'http://www.lizard.ws',
-          download_url='https://pypi.python.org/lizard/',
-          license='MIT',
-          platforms='any',
-          classifiers = ['Development Status :: 5 - Production/Stable',
-                     'Intended Audience :: Developers',
-                     'Intended Audience :: End Users/Desktop',
-                     'License :: Freeware',
-                     'Operating System :: POSIX',
-                     'Operating System :: Microsoft :: Windows',
-                     'Operating System :: MacOS :: MacOS X',
-                     'Topic :: Software Development :: Quality Assurance',
-                     'Programming Language :: C',
-                     'Programming Language :: C++',
-                     'Programming Language :: Java',
-                     'Programming Language :: JavaScript',
-                     'Programming Language :: Objective C',
-                     'Programming Language :: Python',
-                     'Programming Language :: Python :: 2.7',
-                     'Programming Language :: Python :: 3.2',
-                     'Programming Language :: Python :: 3.3',
-                     'Programming Language :: Python :: 3.4',
-                     'Programming Language :: Python :: 3.5'],
-          packages = ['lizard_ext', 'lizard_languages'],
-          py_modules = ['lizard'],
-          author = 'Terry Yin',
-          author_email = 'terry@odd-e.com',
-          scripts = ['lizard.bat', 'lizard', 'hfcca.bat', 'hfcca']
-          )
-
-if __name__ == "__main__":
-    import sys
-    #install('hfcca')
-    install('lizard')
+    long_description=open('README.rst').read(),
+    url='http://www.lizard.ws',
+    download_url='https://pypi.python.org/lizard/',
+    license='MIT',
+    platforms='any',
+    classifiers=['Development Status :: 5 - Production/Stable',
+                    'Intended Audience :: Developers',
+                    'Intended Audience :: End Users/Desktop',
+                    'License :: Freeware',
+                    'Operating System :: POSIX',
+                    'Operating System :: Microsoft :: Windows',
+                    'Operating System :: MacOS :: MacOS X',
+                    'Topic :: Software Development :: Quality Assurance',
+                    'Programming Language :: C',
+                    'Programming Language :: C++',
+                    'Programming Language :: Java',
+                    'Programming Language :: JavaScript',
+                    'Programming Language :: Objective C',
+                    'Programming Language :: Python',
+                    'Programming Language :: Python :: 2.7',
+                    'Programming Language :: Python :: 3.2',
+                    'Programming Language :: Python :: 3.3',
+                    'Programming Language :: Python :: 3.4',
+                    'Programming Language :: Python :: 3.5'],
+    packages=['lizard_ext', 'lizard_languages'],
+    py_modules=['lizard'],
+    entry_points={'console_scripts': ['lizard = lizard:main']},
+    author='Terry Yin',
+    author_email='terry@odd-e.com',
+)

--- a/test/testApplication.py
+++ b/test/testApplication.py
@@ -1,7 +1,6 @@
 import unittest
 from mock import patch
 import lizard
-from lizard import lizard_main
 import os
 import sys
 
@@ -20,7 +19,7 @@ class TestApplication(unittest.TestCase):
 
         os_walk.return_value = [('.', [], [])]
         print_result.side_effect = check_empty_result
-        lizard_main(['lizard'])
+        lizard.main(['lizard'])
 
     def testFilesWithFunction(self, print_result, os_walk, mock_open, _):
         def check_result(result, options, scheme):
@@ -31,7 +30,7 @@ class TestApplication(unittest.TestCase):
         os_walk.return_value = [('.', [], ['a.cpp'])]
         mock_open.return_value = "void foo(){}"
         print_result.side_effect = check_result
-        lizard_main(['lizard'])
+        lizard.main(['lizard'])
 
 
 class IntegrationTests(unittest.TestCase):
@@ -63,7 +62,7 @@ class IntegrationTests(unittest.TestCase):
             return self.returned_warning_count
         mock_open.return_value = src
         print_result.side_effect = store_result
-        lizard_main(argv)
+        lizard.main(argv)
         return self.fileInfos
 
     @patch('lizard.md5_hash_file')
@@ -89,5 +88,3 @@ class IntegrationTests(unittest.TestCase):
         self.returned_warning_count = 6
         self.runApplicationWithArgv(['lizard', '-C5'])
         mock_exit.assert_called_with(1)
-
-


### PR DESCRIPTION
The setup configurations
and the entry points to the lizard.py are simplified.
System specific bat files are removed.
The `hfcca` entry point is removed.

The changes may break scripts
that use the deleted entry points.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/161)
<!-- Reviewable:end -->
