### PR TITLE
Add 'ignore any warnings' for the exit code

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -152,9 +152,12 @@ def arg_parser(prog=None):
                         dest="printer")
     parser.add_argument("-i", "--ignore_warnings",
                         help='''If the number of warnings is equal or less
-                        than the number,
-                        the tool will exit normally, otherwise it will generate
-                        error. Useful in makefile for legacy code.''',
+                        than the number, the tool will exit normally;
+                        otherwise, it will generate error.
+                        If the number is negative,
+                        the tool exits normally
+                        regardless of the number of warnings.
+                        Useful in makefile for legacy code.''',
                         type=int,
                         dest="number",
                         default=0)
@@ -972,7 +975,7 @@ def main(argv=None):
         options.languages,
         regression=schema.any_regression())
     warning_count = printer(result, options, schema)
-    if options.number < warning_count:
+    if 0 <= options.number < warning_count:
         sys.exit(1)
 
 

--- a/test/testApplication.py
+++ b/test/testApplication.py
@@ -88,3 +88,13 @@ class IntegrationTests(unittest.TestCase):
         self.returned_warning_count = 6
         self.runApplicationWithArgv(['lizard', '-C5'])
         mock_exit.assert_called_with(1)
+        self.runApplicationWithArgv(['lizard', '-i5'])
+        mock_exit.assert_called_with(1)
+
+    @patch.object(sys, 'exit')
+    def test_exit_code_ignore_warnings(self, mock_exit):
+        self.returned_warning_count = 6
+        self.runApplicationWithArgv(['lizard', '-i6'])
+        self.assertFalse(mock_exit.called)
+        self.runApplicationWithArgv(['lizard', '-i', '-1'])
+        self.assertFalse(mock_exit.called)


### PR DESCRIPTION
Having trouble with setting high enough ignore for Makefiles?
Set it to infinity!
(infinity being -1 or less)
Call this a pessimistic math.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/167)
<!-- Reviewable:end -->
