### PR TITLE
Switch from nose to pytest

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,4 +10,4 @@ install:
 build: off
 
 test_script:
-    - C:\%PYTHON%\Scripts\nosetests test\
+    - C:\%PYTHON%\Scripts\pytest test\

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ all: extensive pylint
 extensive: tests pep8
 
 tests:
-	nosetests test
+	py.test test
 
 tests3:
 	python3 -m unittest test

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -3,3 +3,4 @@ nose
 pycodestyle
 wheel
 pylint
+pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[tool:pytest]
+python_files = test*

--- a/test/testCyclomaticComplexity.py
+++ b/test/testCyclomaticComplexity.py
@@ -1,91 +1,51 @@
-import unittest
 from .testHelpers import get_cpp_function_list
 
-class TestCppCyclomaticComplexity(unittest.TestCase):
+import pytest
 
-    def test_one_function_with_no_condition(self):
-        result = get_cpp_function_list("int fun(){}")
-        self.assertEqual(1, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_one_condition(self):
-        result = get_cpp_function_list("int fun(){if(a){xx;}}")
-        self.assertEqual(2, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_question_mark(self):
-        result = get_cpp_function_list("int fun(){return (a)?b:c;}")
-        self.assertEqual(2, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_forever_loop(self):
-        result = get_cpp_function_list("int fun(){for(;;){dosomething();}}")
-        self.assertEqual(2, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_and(self):
-        result = get_cpp_function_list("int fun(){if(a&&b){xx;}}")
-        self.assertEqual(3, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_else_if(self):
-        result = get_cpp_function_list("int fun(){if(a)b;else if (c) d;}")
-        self.assertEqual(3, result[0].cyclomatic_complexity)
-
-    def test_sharp_if_and_sharp_elif_counts_in_cc_number(self):
-        result = get_cpp_function_list('''
-                int main(){
-                #ifdef A
-                #elif (defined E)
-                #endif
-                }''')
-        self.assertEqual(1, len(result))
-        self.assertEqual(3, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_r_value_ref_in_parameter(self):
-        result = get_cpp_function_list("int make(Args&&... args){}")
-        self.assertEqual(1, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_r_value_ref_in_body(self):
-        result = get_cpp_function_list("int f() {Args&& a=b;}")
-        self.assertEqual(1, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_r_value_ref_in_body(self):
-        result = get_cpp_function_list("int f() {Args&& a=b;}")
-        self.assertEqual(1, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_non_r_value_ref_in_body(self):
-        result = get_cpp_function_list("int f() {a && b==c;}")
-        self.assertEqual(2, result[0].cyclomatic_complexity)
-
-    def test_two_function_with_non_r_value_ref_in_body(self):
-        result = get_cpp_function_list("""
-        x c() {
-          if (a && b) {
-          }
+@pytest.mark.parametrize(
+    "description,code,ccn",
+    [("no condition", "int fun() {}", [1]),
+     ("one condition", "int fun(){if(a){xx;}}", [2]),
+     ("ternary operator", "int fun(){return (a)?b:c;}", [2]),
+     ("forever_loop", "int fun(){for(;;){dosomething();}}", [2]),
+     ("and operator", "int fun(){if(a&&b){xx;}}", [3]),
+     ("if-else-if", "int fun(){if(a)b;else if (c) d;}", [3]),
+     ("macro if-elif",
+      """int main(){
+            #ifdef A
+            #elif (defined E)
+            #endif
+         }""",
+      [3]),
+     ("r-value reference in parameter", "int make(Args&&... args){}", [1]),
+     ("r-value reference in body", "int f() {Args&& a=b;}", [1]),
+     ("non r-value reference in body", "int f() {a && b==c;}", [2]),
+     ("typedef with r-value reference", "int f() {typedef int&& rref;}", [1]),
+     ("brace-less control structures",
+      """void c() {
+            if (a > -1 && b>= 0 )
+                if(a != 0)
+                    a = b;
+         }""",
+      [4]),
+     ("function ref qualifier",
+      "struct A { void foo() && { return bar() && baz(); } };",
+      [2]),
+     ("function const ref qualifier",
+      "struct A { void foo() const && { return bar() && baz(); } };",
+      [2]),
+     ("two functions",
+      """x c() {
+            if (a && b) {}
         }
         x a() {
           inputs = c;
-        }
-        """)
-        self.assertEqual(1, result[1].cyclomatic_complexity)
-
-    def test_one_function_with_typedef(self):
-        result = get_cpp_function_list("int f() {typedef int&& rref;}")
-        self.assertEqual(1, result[0].cyclomatic_complexity)
-
-    def test_one_function_with_statement_no_curly_brackets(self):
-        result = get_cpp_function_list("""
-        x c() {
-        if (a > -1 && b>= 0 )
-              if(a != 0)
-                    a = b;
-        }
-        """)
-        self.assertEqual(4, result[0].cyclomatic_complexity)
-
-    def test_ref_qualifiers(self):
-        """C++11 rvalue ref qualifiers look like AND operator."""
-        result = get_cpp_function_list(
-                "struct A { void foo() && { return bar() && baz(); } };")
-        self.assertEqual(1, len(result))
-        self.assertEqual(2, result[0].cyclomatic_complexity)
-        result = get_cpp_function_list(
-                "struct A { void foo() const && { return bar() && baz(); } };")
-        self.assertEqual(1, len(result))
-        self.assertEqual(2, result[0].cyclomatic_complexity)
+        }""",
+      [3, 1])
+     ])
+def test_cpp_ccn(description, code, ccn):
+    result = get_cpp_function_list(code)
+    assert result, "Interpretation failure"
+    assert len(result) == len(ccn), "Incorrect number of functions"
+    for expected, value in zip(ccn, (x.cyclomatic_complexity for x in result)):
+        assert value == expected, description


### PR DESCRIPTION
Pytest is awesome with built-in parametrization and mocking.
An example refactoring of CCN tests is provided.
It removes a lot of boilerplate.
The transition can be gradual since Pytest can run Nose tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/terryyin/lizard/175)
<!-- Reviewable:end -->
