### PR TITLE
Add CSV output transform

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ nosetests.xml
 dist/
 .cache/
 .pypirc
+*.sw[a-z]

--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dist/
 .cache/
 .pypirc
 *.sw[a-z]
+.idea

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,6 +1,0 @@
-<?xml version="1.0" encoding="UTF-8"?>
-<project version="4">
-  <component name="VcsDirectoryMappings">
-    <mapping directory="$PROJECT_DIR$" vcs="Git" />
-  </component>
-</project>

--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project version="4">
+  <component name="VcsDirectoryMappings">
+    <mapping directory="$PROJECT_DIR$" vcs="Git" />
+  </component>
+</project>

--- a/lizard.py
+++ b/lizard.py
@@ -38,6 +38,7 @@ except ImportError:
     sys.exit(2)
 try:
     from lizard_ext import print_xml
+    from lizard_ext import print_csv
     from lizard_ext import html_output
     from lizard_ext import auto_open, auto_read
 except ImportError:
@@ -184,6 +185,12 @@ def arg_parser(prog=None):
                         server''',
                         action="store_const",
                         const=print_xml,
+                        dest="printer")
+    parser.add_argument("--csv",
+                        help='''Generate CSV output as a transform of the
+                        default output''',
+                        action="store_const",
+                        const=print_csv,
                         dest="printer")
     parser.add_argument("-H", "--html",
                         help='''Output HTML report''',

--- a/lizard_ext/__init__.py
+++ b/lizard_ext/__init__.py
@@ -4,6 +4,7 @@ from __future__ import print_function
 from .htmloutput import html_output
 from .xmloutput import xml_output
 from .auto_open import auto_open, auto_read
+from .csvoutput import print_csv
 
 
 def print_xml(results, options, _):

--- a/lizard_ext/__init__.py
+++ b/lizard_ext/__init__.py
@@ -2,11 +2,15 @@
 
 from __future__ import print_function
 from .htmloutput import html_output
+from .csvoutput import csv_output
 from .xmloutput import xml_output
 from .auto_open import auto_open, auto_read
-from .csvoutput import print_csv
 
 
 def print_xml(results, options, _):
     print(xml_output(list(results), options.verbose))
     return 0
+
+
+def print_csv(results, options, _):
+    return csv_output(list(results), options.verbose)

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -28,7 +28,7 @@ def csv_output(result, verbose):
         if source_file:
             for source_function in source_file.function_list:
                 if source_function:
-                    print('{},{},{},{},{},"{}","{}","{}","{}"'.format(
+                    print('{},{},{},{},{},"{}","{}","{}",{},{}'.format(
                         source_function.nloc,
                         source_function.cyclomatic_complexity,
                         source_function.token_count,

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -17,11 +17,6 @@ due to the nature of CSV outputs. The differences are:
 '''
 
 
-def print_csv(results, options, _):
-    csv_output(list(results), options.verbose)
-    return 0
-
-
 def csv_output(result, verbose):
     print("NLOC,CCN,token,PARAM,length,location,file,function,start,end")
     for source_file in result:

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -1,0 +1,44 @@
+'''
+This module extends the default output formatting to include CSV.
+
+The output is intended to be the same in structure, with additional
+tokens (to reduce the need to post-process), and a reduced verbosity
+due to the nature of CSV outputs. The differences are:
+
+ * No summary of the included files, only the output
+   respective of each function.
+ * No additional output for functions that break any CCN
+   thresholds.
+ * Each line has four additional, individual tokens:
+     * File name
+     * Function Name
+     * Function line start
+     * Function line end
+'''
+def print_csv(results, options, _):
+    csv_output(list(results), options.verbose)
+    return 0
+
+def csv_output(result, verbose):
+    print "NLOC,CCN,token,PARAM,length,location,file,function,start,end"
+    for source_file in result:
+        if source_file:
+            for source_function in source_file.function_list:
+                if source_function:
+                    print('{},{},{},{},{},"{}","{}","{}","{}"'.format(
+                        source_function.nloc,
+                        source_function.cyclomatic_complexity,
+                        source_function.token_count,
+                        len(source_function.parameters),
+                        source_function.end_line - source_function.start_line,
+                        "{}@{}-{}@{}".format(
+                            source_function.name,
+                            source_function.start_line,
+                            source_function.end_line,
+                            source_file.filename
+                        ),
+                        source_file.filename,
+                        source_function.name,
+                        source_function.start_line,
+                        source_function.end_line
+                    ))

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -15,12 +15,15 @@ due to the nature of CSV outputs. The differences are:
      * Function line start
      * Function line end
 '''
+
+
 def print_csv(results, options, _):
     csv_output(list(results), options.verbose)
     return 0
 
+
 def csv_output(result, verbose):
-    print "NLOC,CCN,token,PARAM,length,location,file,function,start,end"
+    print("NLOC,CCN,token,PARAM,length,location,file,function,start,end")
     for source_file in result:
         if source_file:
             for source_function in source_file.function_list:

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -1,0 +1,38 @@
+from mock import Mock, patch
+import unittest
+import sys
+from lizard_ext import csv_output
+from test.helper_stream import StreamStdoutTestCase
+from lizard import parse_args, print_and_save_modules, FunctionInfo, FileInformation,\
+    get_extensions, OutputScheme
+
+
+class TestCSVOutput(StreamStdoutTestCase):
+
+
+    def setUp(self):
+        StreamStdoutTestCase.setUp(self)
+        self.option = parse_args("app")
+        self.foo = FunctionInfo("foo", 'FILENAME', 100)
+        self.fileSummary = FileInformation("FILENAME", 123, [self.foo])
+        self.extensions = get_extensions([])
+        self.scheme = OutputScheme(self.extensions)
+
+
+    def test_csv_output(self):
+        csv_output([self.fileSummary], self.option)
+        self.assertRegexpMatches(sys.stdout.stream,
+                                 r"NLOC,CCN,token,PARAM,length,location,file,function,start,end")
+
+
+    def test_print_fileinfo(self):
+        self.foo.end_line = 100
+        self.foo.cyclomatic_complexity = 16
+        fileStat = FileInformation("FILENAME", 1, [self.foo])
+
+        csv_output([fileStat], False)
+
+        self.assertEquals(
+            '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo",100,100',
+            sys.stdout.stream.splitlines()[1]
+        )


### PR DESCRIPTION
Pretty much what it says: 

Using "--csv" at the command line (I wasn't able to find a logical one-char short switch), will transform the output into CSV.

The output will be identical in structure to the default output, but with some additions: 
* New tokens for each line
* Less verbosity (will not summarize files, will not highlight those that breached a threshold)