### PR TITLE
Using "verbose" flag to toggle CSV header

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -133,6 +133,8 @@ Options
                         "./folder/*" exclude everything in the folder
                         recursively. Multiple patterns can be specified. Don't
                         forget to add "" around the pattern.
+  --csv                 Generate CSV output as a transform of the default
+                        output
   -X, --xml             Generate XML in cppncss style instead of the tabular
                         output. Useful to generate report in Jenkins server
   -t WORKING_THREADS, --working_threads WORKING_THREADS

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -18,7 +18,9 @@ due to the nature of CSV outputs. The differences are:
 
 
 def csv_output(result, verbose):
-    print("NLOC,CCN,token,PARAM,length,location,file,function,start,end")
+    if verbose:
+        print("NLOC,CCN,token,PARAM,length,location,file,function,start,end")
+
     for source_file in result:
         if source_file:
             for source_function in source_file.function_list:

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -19,10 +19,18 @@ class TestCSVOutput(StreamStdoutTestCase):
         self.scheme = OutputScheme(self.extensions)
 
 
-    def test_csv_output(self):
-        csv_output([self.fileSummary], self.option)
+    def test_csv_header(self):
+        csv_output([self.fileSummary], True)
         self.assertRegexpMatches(sys.stdout.stream,
                                  r"NLOC,CCN,token,PARAM,length,location,file,function,start,end")
+
+
+    def test_csv_no_header(self):
+        csv_output([self.fileSummary], False)
+        self.assertEquals(
+            '1,1,1,0,0,"foo@100-100@FILENAME","FILENAME","foo",100,100',
+            sys.stdout.stream.splitlines()[0]
+        )
 
 
     def test_print_fileinfo(self):
@@ -30,7 +38,7 @@ class TestCSVOutput(StreamStdoutTestCase):
         self.foo.cyclomatic_complexity = 16
         fileStat = FileInformation("FILENAME", 1, [self.foo])
 
-        csv_output([fileStat], False)
+        csv_output([fileStat], True)
 
         self.assertEquals(
             '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo",100,100',


### PR DESCRIPTION
A new toggle to include/exclude the CSV header, when using the --csv output type. Tests and README updated appropriately.