### PR TITLE
adding an _expect_declaration_name state for Swift

### DIFF
--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -32,7 +32,7 @@ class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
             self._state = self._function_name
         if token == 'init':
             self._function_name(token)
-        if token in ('get', 'set', 'deinit'):
+        if token in ('get', 'set', 'willSet', 'didSet', 'deinit'):
             self.context.start_new_function(token)
             self._state = self._expect_function_impl
         if token == 'protocol':
@@ -40,7 +40,7 @@ class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
         if token in ('let', 'var', 'case', ','):
             self._state = self._expect_declaration_name
 
-    def _expect_declaration_name(self, token):
+    def _expect_declaration_name(self, _):
         self._state = self._state_global
 
     def _function_name(self, token):

--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -30,7 +30,7 @@ class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
     def _state_global(self, token):
         if token == 'func':
             self._state = self._function_name
-        if token == 'init':
+        if token in ('init', 'subscript'):
             self._function_name(token)
         if token in ('get', 'set', 'willSet', 'didSet', 'deinit'):
             self.context.start_new_function(token)

--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -37,6 +37,11 @@ class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
             self._state = self._expect_function_impl
         if token == 'protocol':
             self._state = self._protocol
+        if token in ('let', 'var', 'case', ','):
+            self._state = self._expect_declaration_name
+
+    def _expect_declaration_name(self, token):
+        self._state = self._state_global
 
     def _function_name(self, token):
         self.context.start_new_function(token)

--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -40,12 +40,14 @@ class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
         if token in ('let', 'var', 'case', ','):
             self._state = self._expect_declaration_name
 
-    def _expect_declaration_name(self, _):
-        self._state = self._state_global
+    def _expect_declaration_name(self, token):
+        if token != '`':
+            self._state = self._state_global
 
     def _function_name(self, token):
-        self.context.start_new_function(token)
-        self._state = self._expect_function_dec
+        if token != '`':
+            self.context.start_new_function(token)
+            self._state = self._expect_function_dec
 
     def _expect_function_dec(self, token):
         if token == '(':

--- a/test/test_languages/testSwift.py
+++ b/test/test_languages/testSwift.py
@@ -93,17 +93,38 @@ class Test_parser_for_Swift(unittest.TestCase):
                 ''')
         self.assertEqual(0, len(result))
 
+#https://docs.swift.org/swift-book/LanguageGuide/Initialization.html
     def test_init(self):
         result = get_swift_function_list('''
             init() {}
                 ''')
         self.assertEqual("init", result[0].name)
 
+#https://docs.swift.org/swift-book/LanguageGuide/Deinitialization.html
     def test_deinit(self):
         result = get_swift_function_list('''
             deinit {}
                 ''')
         self.assertEqual("deinit", result[0].name)
+
+#https://docs.swift.org/swift-book/LanguageGuide/Subscripts.html
+    def test_subscript(self):
+        result = get_swift_function_list('''
+            override subscript(index: Int) -> Int {}
+                ''')
+        self.assertEqual("subscript", result[0].name)
+
+#https://stackoverflow.com/a/30593673
+    def test_labeled_subscript(self):
+        result = get_swift_function_list('''
+            extension Collection {
+                /// Returns the element at the specified index iff it is within bounds, otherwise nil.
+                subscript (safe index: Index) -> Iterator.Element? {
+                    return indices.contains(index) ? self[index] : nil
+                }
+            }
+                ''')
+        self.assertEqual("subscript", result[0].name)
 
     def test_getter_setter(self):
         result = get_swift_function_list('''
@@ -124,6 +145,70 @@ class Test_parser_for_Swift(unittest.TestCase):
                 ''')
         self.assertEqual("get", result[0].name)
         self.assertEqual("set", result[1].name)
+
+#https://docs.swift.org/swift-book/LanguageGuide/Properties.html#ID259
+    def test_explicit_getter_setter(self):
+        result = get_swift_function_list('''
+            var center: Point {
+                get {
+                    let centerX = origin.x + (size.width / 2)
+                    let centerY = origin.y + (size.height / 2)
+                    return Point(x: centerX, y: centerY)
+                }
+                set(newCenter) {
+                    origin.x = newCenter.x - (size.width / 2)
+                    origin.y = newCenter.y - (size.height / 2)
+                }
+            }
+                ''')
+        self.assertEqual("get", result[0].name)
+        self.assertEqual("set", result[1].name)
+
+    def test_willset_didset(self):
+        result = get_swift_function_list('''
+            var cue = -1 {
+                willSet {
+                    if newValue != cue {
+                        tableView.reloadData()
+                    }
+                }
+                didSet {
+                    tableView.scrollToRow(at: IndexPath(row: cue, section: 0), at: .bottom, animated: true)
+                }
+            }
+                ''')
+        self.assertEqual("willSet", result[0].name)
+        self.assertEqual("didSet", result[1].name)
+
+#https://docs.swift.org/swift-book/LanguageGuide/Properties.html#ID262
+    def test_explicit_willset_didset(self):
+        result = get_swift_function_list('''
+            class StepCounter {
+                var totalSteps: Int = 0 {
+                    willSet(newTotalSteps) {
+                        print("About to set totalSteps to \(newTotalSteps)")
+                    }
+                    didSet {
+                        if totalSteps > oldValue  {
+                            print("Added \(totalSteps - oldValue) steps")
+                        }
+                    }
+                }
+            }
+                ''')
+        self.assertEqual("willSet", result[0].name)
+        self.assertEqual("didSet", result[1].name)
+
+    def test_keyword_declarations(self):
+        result = get_swift_function_list('''
+            enum Func {
+                static var `init`: Bool?, willSet: Bool?
+                static let `deinit` = 0, didSet = 0
+                case `func`; case get, set
+                func `default`() {}
+            }
+                ''')
+        self.assertEqual("default", result[0].name)
 
     def test_generic_function(self):
         result = get_swift_function_list('''


### PR DESCRIPTION
This is an untested attempt to fix #240 by adding a declarative state to ignore variable names like `get` or `set`.