### PR TITLE
Fixed Issue 265: ignore `for` label name by swift.

### DIFF
--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -31,7 +31,6 @@ class SwiftReader(CodeReader, CCppCommentsMixin):
         def replace_label(tokens, target, replace):
             for i in range(0, len(tokens) - len(target)):
                 if tokens[i:i + len(target)] == target:
-                    print(tokens[i:i + len(target)])
                     for j in range(0, len(replace)):
                         tokens[i + j] = replace[j]
             return tokens

--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -27,17 +27,19 @@ class SwiftReader(CodeReader, CCppCommentsMixin):
 
     def preprocess(self, tokens):
         tokens = list(t for t in tokens if not t.isspace() or t == '\n')
+
         def replace_label(tokens, target, replace):
             for i in range(0, len(tokens) - len(target)):
-                if tokens[i : i + len(target)] == target:
-                    print(tokens[i : i + len(target)])
+                if tokens[i:i + len(target)] == target:
+                    print(tokens[i:i + len(target)])
                     for j in range(0, len(replace)):
                         tokens[i + j] = replace[j]
             return tokens
-        for condition in (c for c in self.conditions if c.isalpha()):
-            tokens = replace_label(tokens, ["(", condition, ":"], ["(", "_" + condition, ":"])
-            tokens = replace_label(tokens, [",", condition, ":"], [",", "_" + condition, ":"])
+        for c in (c for c in self.conditions if c.isalpha()):
+            tokens = replace_label(tokens, ["(", c, ":"], ["(", "_" + c, ":"])
+            tokens = replace_label(tokens, [",", c, ":"], [",", "_" + c, ":"])
         return tokens
+
 
 class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
     def _state_global(self, token):

--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -25,6 +25,19 @@ class SwiftReader(CodeReader, CCppCommentsMixin):
             r"|\?\?" +
             addition)
 
+    def preprocess(self, tokens):
+        tokens = list(t for t in tokens if not t.isspace() or t == '\n')
+        def replace_label(tokens, target, replace):
+            for i in range(0, len(tokens) - len(target)):
+                if tokens[i : i + len(target)] == target:
+                    print(tokens[i : i + len(target)])
+                    for j in range(0, len(replace)):
+                        tokens[i + j] = replace[j]
+            return tokens
+        for condition in (c for c in self.conditions if c.isalpha()):
+            tokens = replace_label(tokens, ["(", condition, ":"], ["(", "_" + condition, ":"])
+            tokens = replace_label(tokens, [",", condition, ":"], [",", "_" + condition, ":"])
+        return tokens
 
 class SwiftStates(CodeStateMachine):  # pylint: disable=R0903
     def _state_global(self, token):

--- a/test/test_languages/testSwift.py
+++ b/test/test_languages/testSwift.py
@@ -233,3 +233,17 @@ class Test_parser_for_Swift(unittest.TestCase):
             }
         ''')
         self.assertEqual(1, result[0].cyclomatic_complexity)
+
+    def test_for_label(self):
+        result = get_swift_function_list('''
+            func f0() { something(for: .something) }
+            func f1() { something(for :.something) }
+            func f2() { something(for : .something) }
+            func f3() { something(for: isValid ? true : false) }
+            func f4() { something(label1: .something, label2: .something, for: .something) }
+        ''')
+        self.assertEqual(1, result[0].cyclomatic_complexity)
+        self.assertEqual(1, result[1].cyclomatic_complexity)
+        self.assertEqual(1, result[2].cyclomatic_complexity)
+        self.assertEqual(2, result[3].cyclomatic_complexity)
+        self.assertEqual(1, result[4].cyclomatic_complexity)


### PR DESCRIPTION
This code's ccn is 1.

```swift
something(for: .something)
```

##### remarks

Because I don't know how to scan arrays efficiently in Python, it's an index-based implementation. I would like to point out.