### PR TITLE
Fixed Issue 267: guard clause is not counted by ccn.

### DIFF
--- a/lizard_languages/swift.py
+++ b/lizard_languages/swift.py
@@ -11,6 +11,8 @@ class SwiftReader(CodeReader, CCppCommentsMixin):
 
     ext = ['swift']
     language_names = ['swift']
+    _conditions = set(['if', 'for', 'while', '&&', '||', '?', 'catch',
+                      'case', 'guard'])
 
     def __init__(self, context):
         super(SwiftReader, self).__init__(context)

--- a/test/test_languages/testSwift.py
+++ b/test/test_languages/testSwift.py
@@ -233,3 +233,11 @@ class Test_parser_for_Swift(unittest.TestCase):
             }
         ''')
         self.assertEqual(1, result[0].cyclomatic_complexity)
+
+    def test_guard(self):
+        # `guard isValid else { return }` equal to `if isValid { return }`
+        # ccn = 2
+        result = get_swift_function_list('''
+            func f() { guard isValid else { return } }
+        ''')
+        self.assertEqual(2, result[0].cyclomatic_complexity)


### PR DESCRIPTION
This code's ccn is 2.

```swift
guard isValid else { return }
```

This code is equal `if isValid { return }`, so lizard shold output 2.
