### PR TITLE
Fixed warning threshold inconsistency in HTML output.

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -965,7 +965,7 @@ def infer_printer_from_file_ext(path):
 
 def open_output_file(path):
     try:
-        return open(path, 'w', encoding='utf-8')
+        return open(path, 'w')
     except OSError:
         msg = "Error: failed to open output file '{}'\n.".format(path)
         sys.stderr.write(msg)

--- a/lizard.py
+++ b/lizard.py
@@ -128,6 +128,13 @@ def arg_parser(prog=None):
                         ''',
                         type=str,
                         dest="input_file")
+    parser.add_argument("-o", "--output_file",
+                        help='''Output file. The output format is inferred
+                        from the file extension (e.g. .html), unless it is
+                        explicitly specified (e.g. using --xml).
+                        ''',
+                        type=str,
+                        dest="output_file")
     parser.add_argument("-L", "--length",
                         help='''Threshold for maximum function length
                         warning. The default value is %d.
@@ -933,7 +940,36 @@ def parse_args(argv):
         opt.thresholds["length"] = opt.length
     if "parameter_count" not in opt.thresholds:
         opt.thresholds["parameter_count"] = opt.arguments
+    if opt.output_file:
+        inferred_printer = infer_printer_from_file_ext(opt.output_file)
+        if inferred_printer:
+            if not opt.printer:
+                opt.printer = inferred_printer
+            else:
+                msg = "Warning: overriding output file extension.\n"
+                sys.stderr.write(msg)
     return opt
+
+
+def infer_printer_from_file_ext(path):
+    mapping = {
+        '.csv': print_csv,
+        '.htm': html_output,
+        '.html': html_output,
+        '.xml': print_xml
+    }
+    _, ext = os.path.splitext(path)
+    printer = mapping.get(ext)
+    return printer
+
+
+def open_output_file(path):
+    try:
+        return open(path, 'w', encoding='utf-8')
+    except OSError:
+        msg = "Error: failed to open output file '{}'\n.".format(path)
+        sys.stderr.write(msg)
+        sys.exit(2)
 
 
 def get_extensions(extension_names):
@@ -977,6 +1013,11 @@ def main(argv=None):
     schema.patch_for_extensions()
     if options.input_file:
         options.paths = auto_read(options.input_file).splitlines()
+    original_stdout = sys.stdout
+    output_file = None
+    if options.output_file:
+        output_file = open_output_file(options.output_file)
+        sys.stdout = output_file
     result = analyze(
         options.paths,
         options.exclude,
@@ -986,6 +1027,9 @@ def main(argv=None):
     warning_count = printer(result, options, schema, AllResult)
     print_extension_results(options.extensions)
     list(result)
+    if output_file:
+        sys.stdout = original_stdout
+        output_file.close()
     if 0 <= options.number < warning_count:
         sys.exit(1)
 

--- a/lizard.py
+++ b/lizard.py
@@ -859,8 +859,11 @@ def get_map_method(working_threads):
 def md5_hash_file(full_path_name):
     ''' return md5 hash of a file '''
     try:
-        with auto_open(full_path_name, mode='rb') as source_file:
-            code_md5 = hashlib.md5(source_file.read())
+        with auto_open(full_path_name, mode='r') as source_file:
+            if sys.version_info[0] == 3:
+                code_md5 = hashlib.md5(source_file.read().encode('utf-8'))
+            else:
+                code_md5 = hashlib.md5(source_file.read())
         return code_md5.hexdigest()
     except IOError:
         return None

--- a/lizard.py
+++ b/lizard.py
@@ -21,6 +21,7 @@ languages including C/C++ (doesn't require all the header files).
 For more information visit http://www.lizard.ws
 """
 from __future__ import print_function, division
+import codecs
 import sys
 import itertools
 import re
@@ -965,7 +966,7 @@ def infer_printer_from_file_ext(path):
 
 def open_output_file(path):
     try:
-        return open(path, 'w')
+        return codecs.open(path, 'w', encoding='utf8')
     except OSError:
         msg = "Error: failed to open output file '{}'\n.".format(path)
         sys.stderr.write(msg)

--- a/lizard.py
+++ b/lizard.py
@@ -859,11 +859,8 @@ def get_map_method(working_threads):
 def md5_hash_file(full_path_name):
     ''' return md5 hash of a file '''
     try:
-        with auto_open(full_path_name, mode='r') as source_file:
-            if sys.version_info[0] == 3:
-                code_md5 = hashlib.md5(source_file.read().encode('utf-8'))
-            else:
-                code_md5 = hashlib.md5(source_file.read())
+        with auto_open(full_path_name, mode='rb') as source_file:
+            code_md5 = hashlib.md5(source_file.read())
         return code_md5.hexdigest()
     except IOError:
         return None

--- a/lizard_ext/template.html
+++ b/lizard_ext/template.html
@@ -67,20 +67,20 @@
   <tr>
 	<td style="background-color:LightSteelBlue">{{ func.name }}</td>
 	<td></td>
-	{% if func.cyclomatic_complexity >= thresholds["cyclomatic_complexity"] %}
+	{% if func.cyclomatic_complexity > thresholds["cyclomatic_complexity"] %}
 	   <td class="greater-value">{{ func.cyclomatic_complexity }}</td>
 	{% else %}
 	   <td class="lesser-value">{{ func.cyclomatic_complexity }}</td>
 	{% endif %}
 
-	{% if func.nloc >= thresholds["length"] %}
+	{% if func.nloc > thresholds["length"] %}
 	   <td class="greater-value">{{ func.nloc }}</td>
 	{% else %}
 	   <td class="lesser-value">{{ func.nloc}}</td>
 	{% endif %}
 
 	{% if thresholds["token_count"] %}
-	   {% if func.token_count >= thresholds["token_count"] %}
+	   {% if func.token_count > thresholds["token_count"] %}
 	      <td class="greater-value">{{ func.token_count }}</td>
 	   {% else %}
 	      <td class="lesser-value">{{ func.token_count }}</td>
@@ -89,7 +89,7 @@
 	   <td class="value">{{ func.token_count }}</td>
 	{% endif %}
 
-	{% if func.parameters|length >= thresholds["parameter_count"] %}
+	{% if func.parameters|length > thresholds["parameter_count"] %}
 	   <td class="greater-value">{{ func.parameters|length }}</td>
 	{% else %}
 	   <td class="lesser-value">{{ func.parameters|length }}</td>

--- a/test/testOutput.py
+++ b/test/testOutput.py
@@ -87,7 +87,7 @@ class TestWarningOutput(StreamStdoutTestCase):
         print_warnings(self.option, self.scheme, (x for x in []))
 
 
-class TestFileOutput(StreamStdoutTestCase):
+class TestFileInformationOutput(StreamStdoutTestCase):
 
     def test_print_and_save_detail_information(self):
         scheme = OutputScheme([])

--- a/test/testOutputFile.py
+++ b/test/testOutputFile.py
@@ -43,7 +43,7 @@ class TestFileOutputIntegration(unittest.TestCase):
             self.assertEqual(expected_md5, computed_md5)
 
     def test_default(self):
-        self.output_test("test", "ef6dafce35a7d1d76c6c2e0533c5abb6")
+        self.output_test("test", "eac0d9e24290640a281a5a87c6118acc")
 
     def test_csv(self):
         self.output_test("test.csv", "4e808054b31ffbd90e93282f6dd3e95f")
@@ -54,4 +54,4 @@ class TestFileOutputIntegration(unittest.TestCase):
         self.output_test("test.html")
 
     def test_xml(self):
-        self.output_test("test.xml", "cac48f4e8f55fd49306b69aabc2b498e")
+        self.output_test("test.xml", "8338082a4bcf8faaa89a05503a85b315")

--- a/test/testOutputFile.py
+++ b/test/testOutputFile.py
@@ -1,0 +1,57 @@
+from os.path import join
+from shutil import rmtree
+from tempfile import mkdtemp
+import unittest
+from lizard import html_output, print_xml, md5_hash_file, parse_args, main
+
+
+class TestFileOutputArgParsing(unittest.TestCase):
+
+    def test_short(self):
+        args = parse_args(["lizard", "-o test_file"])
+        self.assertEqual("test_file", args.output_file.strip())
+
+    def test_long(self):
+        args = parse_args(["lizard", "--output_file", "test_file"])
+        self.assertEqual("test_file", args.output_file.strip())
+
+    def test_standalone(self):
+        args = parse_args(["lizard", "--output_file", "test_file.html"])
+        self.assertEqual(html_output, args.printer)
+
+    def test_override(self):
+        args = parse_args(["lizard", "--output_file test_file.html", "--xml"])
+        self.assertEqual(print_xml, args.printer)
+
+
+class TestFileOutputIntegration(unittest.TestCase):
+
+    def setUp(self):
+        self.tmp_dir = mkdtemp()
+        print("Tmp directory '{}' created.\n".format(self.tmp_dir))
+
+    def tearDown(self):
+        rmtree(self.tmp_dir)
+        print("Tmp directory '{}' deleted.\n".format(self.tmp_dir))
+
+    def output_test(self, file_name, expected_md5=None):
+        path = join(self.tmp_dir, file_name)
+        args = ["lizard", "--verbose", "--output_file", path, "test/data"]
+        main(args)
+        if expected_md5:
+            computed_md5 = md5_hash_file(path)
+            self.assertEqual(expected_md5, computed_md5)
+
+    def test_default(self):
+        self.output_test("test", "ef6dafce35a7d1d76c6c2e0533c5abb6")
+
+    def test_csv(self):
+        self.output_test("test.csv", "4e808054b31ffbd90e93282f6dd3e95f")
+
+    def test_html(self):
+        # No MD5 check for HTML output, because it is not reproducible
+        # (includes a timestamp).
+        self.output_test("test.html")
+
+    def test_xml(self):
+        self.output_test("test.xml", "cac48f4e8f55fd49306b69aabc2b498e")

--- a/test/testOutputFile.py
+++ b/test/testOutputFile.py
@@ -50,8 +50,6 @@ class TestFileOutputIntegration(unittest.TestCase):
         self.output_test("test.csv", header)
 
     def test_html(self):
-        # No MD5 check for HTML output, because it is not reproducible
-        # (includes a timestamp).
         header = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
         self.output_test("test.html", header)
 

--- a/test/testOutputFile.py
+++ b/test/testOutputFile.py
@@ -2,7 +2,7 @@ from os.path import join
 from shutil import rmtree
 from tempfile import mkdtemp
 import unittest
-from lizard import html_output, print_xml, md5_hash_file, parse_args, main
+from lizard import html_output, print_xml, parse_args, main
 
 
 class TestFileOutputArgParsing(unittest.TestCase):
@@ -34,24 +34,27 @@ class TestFileOutputIntegration(unittest.TestCase):
         rmtree(self.tmp_dir)
         print("Tmp directory '{}' deleted.\n".format(self.tmp_dir))
 
-    def output_test(self, file_name, expected_md5=None):
+    def output_test(self, file_name, expected_first_line):
         path = join(self.tmp_dir, file_name)
         args = ["lizard", "--verbose", "--output_file", path, "test/data"]
         main(args)
-        if expected_md5:
-            computed_md5 = md5_hash_file(path)
-            self.assertEqual(expected_md5, computed_md5)
+        first_line = open(path, 'r').readline().strip('\n')
+        self.assertEqual(first_line, expected_first_line)
 
     def test_default(self):
-        self.output_test("test", "eac0d9e24290640a281a5a87c6118acc")
+        header = "================================================"
+        self.output_test("test", header)
 
     def test_csv(self):
-        self.output_test("test.csv", "4e808054b31ffbd90e93282f6dd3e95f")
+        header = "NLOC,CCN,token,PARAM,length,location,file,function,long_name,start,end"
+        self.output_test("test.csv", header)
 
     def test_html(self):
         # No MD5 check for HTML output, because it is not reproducible
         # (includes a timestamp).
-        self.output_test("test.html")
+        header = "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01 Transitional//EN\" \"http://www.w3.org/TR/html4/loose.dtd\">"
+        self.output_test("test.html", header)
 
     def test_xml(self):
-        self.output_test("test.xml", "8338082a4bcf8faaa89a05503a85b315")
+        header = "<?xml version=\"1.0\" ?>"
+        self.output_test("test.xml", header)


### PR DESCRIPTION
As documented, warnings are generated when metrics (e.g. CCN) are
bigger (>) than the threshold. Thus, we should use the same logic
in the HTML output, and use greater (>) instead of gte (>=).