### PR TITLE
Including coverage, extensions goto_count, statement_count and extended cvs output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,8 @@ all: extensive pylint
 extensive: tests pep8
 
 tests:
-	py.test test
+	coverage run --source=lizard.py,lizard_ext,lizard_language -m pytest test
+	coverage report -m
 
 tests3:
 	python3 -m unittest test

--- a/dev_requirements.txt
+++ b/dev_requirements.txt
@@ -1,4 +1,5 @@
 mock
+coverage
 pygments==2.3.1
 nose
 pycodestyle

--- a/lizard_ext/__init__.py
+++ b/lizard_ext/__init__.py
@@ -1,4 +1,4 @@
-''' extensions of lizard '''
+""" extensions of lizard """
 
 from __future__ import print_function
 from .version import version
@@ -14,5 +14,5 @@ def print_xml(results, options, _, total_factory):
 
 
 def print_csv(results, options, _, total_factory):
-    csv_output(total_factory(list(results)), options.verbose)
+    csv_output(total_factory(list(results)), options)
     return 0

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -1,4 +1,4 @@
-'''
+"""
 This module extends the default output formatting to include CSV.
 
 The output is intended to be the same in structure, with additional
@@ -14,20 +14,42 @@ due to the nature of CSV outputs. The differences are:
      * Function Name
      * Function line start
      * Function line end
-'''
+"""
 
 
-def csv_output(result, verbose):
+def csv_output(result, options):
     result = result.result
-    if verbose:
+
+    extension_variables = []
+    extension_captions = []
+    for extension in options.extensions:
+        if extension.__class__.__name__ == 'LizardExtension':
+            if hasattr(extension, 'FUNCTION_INFO') and \
+                    len(list(extension.FUNCTION_INFO)) == 1:
+                extension_variable = list(extension.FUNCTION_INFO)[0]
+                extension_variables.append(extension_variable)
+                var_extension = extension.FUNCTION_INFO[extension_variable]
+                extension_caption = var_extension['caption'] \
+                    if 'caption' in var_extension else 'No_caption'
+                extension_captions.append(extension_caption)
+
+    if options.verbose:
+        extension_caption = ""
+        for caption in extension_captions:
+            extension_caption = "{},{}".format(extension_caption, caption)
         print("NLOC,CCN,token,PARAM,length,location,file,function," +
-              "long_name,start,end")
+              "long_name,start,end{}".format(extension_caption))
 
     for source_file in result:
         if source_file:
             for source_function in source_file.function_list:
                 if source_function:
-                    print('{},{},{},{},{},"{}","{}","{}","{}",{},{}'.format(
+                    extension_string = ''
+                    for variable in extension_variables:
+                        extension_string = '{},{}'.\
+                            format(extension_string,
+                                   source_function.__getattribute__(variable))
+                    print('{},{},{},{},{},"{}","{}","{}","{}",{},{}{}'.format(
                         source_function.nloc,
                         source_function.cyclomatic_complexity,
                         source_function.token_count,
@@ -43,5 +65,6 @@ def csv_output(result, verbose):
                         source_function.name.replace("\"", "'"),
                         source_function.long_name.replace("\"", "'"),
                         source_function.start_line,
-                        source_function.end_line
+                        source_function.end_line,
+                        extension_string
                     ))

--- a/lizard_ext/lizardexitcount.py
+++ b/lizard_ext/lizardexitcount.py
@@ -1,12 +1,12 @@
-'''
+"""
 This is an extension of lizard, that counts the 'exit points'
 in every function.
-'''
+"""
 
 
-class LizardExtension(object):  # pylint: disable=R0903
+class LizardExtension:  # pylint: disable=R0903
 
-    FUNCTION_INFO = {"exit_count": {"caption": " exits "}}
+    FUNCTION_INFO = {"exit_count": {"caption": "exits"}}
 
     def __call__(self, tokens, reader):
         first_return = False

--- a/lizard_ext/lizardgotocount.py
+++ b/lizard_ext/lizardgotocount.py
@@ -1,0 +1,16 @@
+'''
+This is an extension of lizard, that counts the amount of goto's
+'''
+
+
+class LizardExtension():  # pylint: disable=R0903
+
+    FUNCTION_INFO = {"goto_count": {"caption": " goto's "}}
+
+    def __call__(self, tokens, reader):
+        for token in tokens:
+            if not hasattr(reader.context.current_function, "goto_count"):
+                reader.context.current_function.goto_count = 0
+            if token == "goto":
+                reader.context.current_function.goto_count += 1
+            yield token

--- a/lizard_ext/lizardstatementcount.py
+++ b/lizard_ext/lizardstatementcount.py
@@ -1,0 +1,22 @@
+"""
+This is an extension of lizard, that counts the statements in a function
+"""
+
+
+class LizardExtension:  # pylint: disable=R0903
+
+    FUNCTION_INFO = {"statement_count": {"caption": "statements"}}
+
+    def __call__(self, tokens, reader):
+        for token in tokens:
+            if not hasattr(reader.context.current_function, "statement_count"):
+                reader.context.current_function.statement_count = 0
+            if token == ";":
+                reader.context.current_function.statement_count += 1
+            if token == "if":
+                reader.context.current_function.statement_count += 1
+            if token == "for":
+                reader.context.current_function.statement_count += 1
+            if token == "while":
+                reader.context.current_function.statement_count += 1
+            yield token

--- a/lizard_ext/version.py
+++ b/lizard_ext/version.py
@@ -2,4 +2,4 @@
 # Add a new version in the CHANGELOG.md in the root folder instead
 #
 # pylint: disable=missing-docstring,invalid-name
-version = "1.17.3.1"
+version = "1.17.4.1"

--- a/test/testFunctionGotoCount.py
+++ b/test/testFunctionGotoCount.py
@@ -1,0 +1,18 @@
+import unittest
+from .testHelpers import get_cpp_function_list_with_extension
+from lizard_ext.lizardgotocount import LizardExtension as GotoCounter
+
+class TestFunctionGotoCount(unittest.TestCase):
+
+    def test_empty_function_should_count_as_0(self):
+        result = get_cpp_function_list_with_extension("int fun(){}", GotoCounter())
+        self.assertEqual(0, result[0].goto_count)
+
+    def test_function_name_contains_goto_count_as_0(self):
+        result = get_cpp_function_list_with_extension("int funGoTo(){return 0;}", GotoCounter())
+        self.assertEqual(0, result[0].goto_count)
+
+    def test_function_with_goto_count_as_1(self):
+        result = get_cpp_function_list_with_extension("int fun(){goto label;return 1;}", GotoCounter())
+        self.assertEqual(1, result[0].goto_count)
+

--- a/test/testFunctionStatementCount.py
+++ b/test/testFunctionStatementCount.py
@@ -1,0 +1,31 @@
+import unittest
+from .testHelpers import get_cpp_function_list_with_extension
+from lizard_ext.lizardstatementcount import LizardExtension as StatementCounter
+
+
+class TestFunctionStatementCount(unittest.TestCase):
+
+    def test_empty_function_should_count_as_0(self):
+        result = get_cpp_function_list_with_extension("int fun(){}", StatementCounter())
+        self.assertEqual(0, result[0].statement_count)
+
+    def test_function_with_return_count_as_1(self):
+        result = get_cpp_function_list_with_extension("int fun(){return 0;}", StatementCounter())
+        self.assertEqual(1, result[0].statement_count)
+
+    def test_function_with_if_else_count_as_3(self):
+        result = get_cpp_function_list_with_extension(
+            "int fun(){if (0) { return 0; } else { return 1;}}", StatementCounter())
+        self.assertEqual(3, result[0].statement_count)
+
+    def test_function_with_for_count_as_6(self):
+        result = get_cpp_function_list_with_extension(
+            'int fun(){int i; for(i=0;i<2;i++) { print("%d",i); } return 1;}',
+            StatementCounter())
+        self.assertEqual(6, result[0].statement_count)
+
+    def test_function_with_while_count_as_5(self):
+        result = get_cpp_function_list_with_extension(
+            'int fun(){int i=0; while(i<2) { print("%d",i); i++; } return 1;}',
+            StatementCounter())
+        self.assertEqual(5, result[0].statement_count)

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -9,7 +9,6 @@ from lizard import parse_args, print_and_save_modules, FunctionInfo, FileInforma
 
 class TestCSVOutput(StreamStdoutTestCase):
 
-
     def setUp(self):
         StreamStdoutTestCase.setUp(self)
         self.option = parse_args("app")
@@ -18,27 +17,85 @@ class TestCSVOutput(StreamStdoutTestCase):
         self.extensions = get_extensions([])
         self.scheme = OutputScheme(self.extensions)
 
-
     def test_csv_header(self):
-        csv_output(AllResult([self.fileSummary]), True)
+        options_mock = Mock()
+        options_mock.verbose = True
+        options_mock.extensions = []
+        csv_output(AllResult([self.fileSummary]), options_mock)
         self.assertRegexpMatches(sys.stdout.stream,
                                  r"NLOC,CCN,token,PARAM,length,location,file,function,long_name,start,end")
 
+    def test_csv_header_with_extension(self):
+        options_mock = Mock()
+        options_mock.verbose = True
+        extension_mock = Mock()
+        extension_mock.__class__.__name__ = 'LizardExtension'
+        extension_mock.FUNCTION_INFO = {"exit_count": {"caption": "exits"}}
+        options_mock.extensions = [extension_mock]
+
+        results = AllResult([self.fileSummary])
+        results.result[0].function_list[0].exit_count = 1
+        csv_output(results, options_mock)
+
+        self.assertRegexpMatches(sys.stdout.stream,
+                                 r"NLOC,CCN,token,PARAM,length,location,file,function,long_name,start,end,exits")
 
     def test_csv_no_header(self):
-        csv_output(AllResult([self.fileSummary]), False)
+        options_mock = Mock()
+        options_mock.verbose = False
+        options_mock.extensions = []
+        csv_output(AllResult([self.fileSummary]), options_mock)
         self.assertEqual(
             '1,1,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
             sys.stdout.stream.splitlines()[0]
         )
 
+    def test_csv_no_header_with_extension(self):
+        options_mock = Mock()
+        options_mock.verbose = False
+        options_mock.extensions = []
+        extension_mock = Mock()
+        extension_mock.__class__.__name__ = 'LizardExtension'
+        extension_mock.FUNCTION_INFO = {"exit_count": {"caption": "exits"}}
+        options_mock.extensions = [extension_mock]
+
+        results = AllResult([self.fileSummary])
+        results.result[0].function_list[0].exit_count = 1
+        csv_output(results, options_mock)
+
+        self.assertEqual(
+            '1,1,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100,1',
+            sys.stdout.stream.splitlines()[0]
+        )
+
+
 
     def test_print_fileinfo(self):
+        options_mock = Mock()
+        options_mock.verbose = True
+        options_mock.extensions = []
+
         self.foo.end_line = 100
         self.foo.cyclomatic_complexity = 16
         fileStat = FileInformation("FILENAME", 1, [self.foo])
 
-        csv_output(AllResult([fileStat]), True)
+        csv_output(AllResult([fileStat]), options_mock)
+
+        self.assertEqual(
+            '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
+            sys.stdout.stream.splitlines()[1]
+        )
+
+    def test_print_extension(self):
+        options_mock = Mock()
+        options_mock.verbose = True
+        options_mock.extensions = []
+
+        self.foo.end_line = 100
+        self.foo.cyclomatic_complexity = 16
+        fileStat = FileInformation("FILENAME", 1, [self.foo])
+
+        csv_output(AllResult([fileStat]), options_mock)
 
         self.assertEqual(
             '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',


### PR DESCRIPTION
Hi,

I've got a new request for you. Included in this request are:
- code coverage measurement of the executed unit tests
- added a few extensions: goto counter and (a rather basic) statement counter (including tests)
- extended the cvsoutput method to include the extensions (extended the tests for this)
- Tried to work away as much warnings as possible.

If you have any comments on my code please let me know.

One question: Is there a special reason why the tests use assertEqual instead of the assertRegex as stated by the DeprecationWarning?