### PR TITLE
* Added suggestion of using the simplification as suggested by Terry …

### DIFF
--- a/lizard_ext/extension_base.py
+++ b/lizard_ext/extension_base.py
@@ -1,12 +1,11 @@
-'''Base stuff for extensions'''
+"""Base stuff for extensions"""
 from lizard_languages.code_reader import CodeStateMachine
 
 
 class ExtensionBase(CodeStateMachine):
-    '''Base class for all lizard extensions'''
+    """Base class for all lizard extensions"""
 
-    # pylint: disable=W0221
-    def __call__(self, tokens, reader):
+    def __call__(self, tokens, reader=None):
         self.context = reader.context
         for token in tokens:
             self._state(token)

--- a/lizard_ext/lizardns.py
+++ b/lizard_ext/lizardns.py
@@ -72,10 +72,16 @@ class LizardExtension(ExtensionBase):  # pylint: disable=R0903
     def pile_up_within_block(self):
         self.structure_piles[-1] += 1
         cur_level = sum(self.structure_piles)
+        # Is there a path around _state_global?
+        if not hasattr(self.context.current_function, "max_nested_structures"):
+            self.context.current_function.max_nested_structures = 0
         if self.context.current_function.max_nested_structures < cur_level:
             self.context.current_function.max_nested_structures = cur_level
 
     def _state_global(self, token):
+        # Necessary to prevent functions without nested blocks to fail
+        if not hasattr(self.context.current_function, "max_nested_structures"):
+            self.context.current_function.max_nested_structures = 0
         if token == '{':
             self.structure_piles.append(0)
         elif token in ';}':

--- a/lizard_ext/lizardstatementcount.py
+++ b/lizard_ext/lizardstatementcount.py
@@ -8,15 +8,25 @@ class LizardExtension:  # pylint: disable=R0903
     FUNCTION_INFO = {"statement_count": {"caption": "statements"}}
 
     def __call__(self, tokens, reader):
+        c_family = 'c' in reader.language_names or \
+                   'cpp' in reader.language_names
+
+        block_count = 0
         for token in tokens:
-            if not hasattr(reader.context.current_function, "statement_count"):
-                reader.context.current_function.statement_count = 0
-            if token == ";":
-                reader.context.current_function.statement_count += 1
-            if token == "if":
-                reader.context.current_function.statement_count += 1
-            if token == "for":
-                reader.context.current_function.statement_count += 1
-            if token == "while":
-                reader.context.current_function.statement_count += 1
+            if c_family:
+                if not hasattr(reader.context.current_function,
+                               "statement_count"):
+                    reader.context.current_function.statement_count = 0
+                if token in [';', 'if', 'for', 'while', ':', 'switch']:
+                    reader.context.current_function.statement_count += 1
+                if token == "{":
+                    if block_count != 0:
+                        reader.context.\
+                            current_function.statement_count += 1
+                    block_count += 1
+                if token == "}":
+                    block_count -= 1 if block_count > 0 else 0
+            else:
+                reader.context.current_function.statement_count = None
+
             yield token

--- a/lizard_ext/version.py
+++ b/lizard_ext/version.py
@@ -2,4 +2,4 @@
 # Add a new version in the CHANGELOG.md in the root folder instead
 #
 # pylint: disable=missing-docstring,invalid-name
-version = "1.17.4.1"
+version = "1.17.4"

--- a/test/testFunctionExitCount.py
+++ b/test/testFunctionExitCount.py
@@ -15,3 +15,17 @@ class TestFunctionExitCount(unittest.TestCase):
     def test_two_returns_should_count_as_2(self):
         result = get_cpp_function_list_with_extension("int fun(){return 0;return 1;}", ExitCounter())
         self.assertEqual(2, result[0].exit_count)
+
+    def test_three_returns_should_count_as_3(self):
+        # Using the example from: https://ator1699.home.xs4all.nl/Work/GBS/Doc_and_download/doc/metrics.html#STM19
+        code = """
+void f( int a )
+{
+    return;             /* 1 */
+    if ( a )
+        return;         /* 2 */
+    a++;
+    return;             /* 3 */
+}"""
+        result = get_cpp_function_list_with_extension(code, ExitCounter())
+        self.assertEqual(3, result[0].exit_count)

--- a/test/testFunctionStatementCount.py
+++ b/test/testFunctionStatementCount.py
@@ -1,31 +1,109 @@
 import unittest
-from .testHelpers import get_cpp_function_list_with_extension
+
 from lizard_ext.lizardstatementcount import LizardExtension as StatementCounter
+from .testHelpers import get_cpp_function_list_with_extension, get_python_function_list_with_extension
 
 
 class TestFunctionStatementCount(unittest.TestCase):
 
+    def test_unsupported_language(self):
+        code = """
+        def Hello_World():
+            print("Hello World")
+
+        Hello_World()
+        """
+        result = get_python_function_list_with_extension(code, StatementCounter())
+        self.assertEqual(None, result[0].statement_count)
+
     def test_empty_function_should_count_as_0(self):
-        result = get_cpp_function_list_with_extension("int fun(){}", StatementCounter())
+        code = """
+        int fun()
+        {
+        }
+        """
+        result = get_cpp_function_list_with_extension(code, StatementCounter())
         self.assertEqual(0, result[0].statement_count)
 
     def test_function_with_return_count_as_1(self):
-        result = get_cpp_function_list_with_extension("int fun(){return 0;}", StatementCounter())
+        code = """
+        int fun()
+        {
+            return 0;     /* 1 */
+        }
+        """
+        result = get_cpp_function_list_with_extension(code, StatementCounter())
         self.assertEqual(1, result[0].statement_count)
 
-    def test_function_with_if_else_count_as_3(self):
+    def test_function_with_if_else_count_as_5(self):
+        code = """
+        int fun()
+        {
+            if (0)        /* 1 */
+            {             /* 2 */
+                return 0; /* 3 */
+            }
+            else
+            {             /* 4 */
+                return 1; /* 5 */
+            }
+        }
+        """
         result = get_cpp_function_list_with_extension(
-            "int fun(){if (0) { return 0; } else { return 1;}}", StatementCounter())
-        self.assertEqual(3, result[0].statement_count)
+            code, StatementCounter())
+        self.assertEqual(5, result[0].statement_count)
 
-    def test_function_with_for_count_as_6(self):
+    def test_function_with_for_count_as_7(self):
+        code = """
+        int fun()
+        {
+            int i;              /* 1 */
+            for (i=0;i<2;i++)   /* 2,3,4 */
+            {                   /* 5 */
+                print("%d",i);  /* 6 */
+            }
+            return 1;           /* 7 */
+        }
+        """
         result = get_cpp_function_list_with_extension(
-            'int fun(){int i; for(i=0;i<2;i++) { print("%d",i); } return 1;}',
+            code,
+            StatementCounter())
+        self.assertEqual(7, result[0].statement_count)
+
+    def test_function_with_while_count_as_6(self):
+        code = """
+        int fun()
+        {
+            int i=0;            /* 1 */ 
+            while(i<2)          /* 2 */
+            {                   /* 3 */
+                print("%d",i);  /* 4 */
+                i++;            /* 5 */
+            }
+            return 1;           /* 6 */
+        }
+        """
+        result = get_cpp_function_list_with_extension(
+            code,
             StatementCounter())
         self.assertEqual(6, result[0].statement_count)
 
-    def test_function_with_while_count_as_5(self):
-        result = get_cpp_function_list_with_extension(
-            'int fun(){int i=0; while(i<2) { print("%d",i); i++; } return 1;}',
-            StatementCounter())
-        self.assertEqual(5, result[0].statement_count)
+    def test_function_with_while_count_as_10(self):
+        # Using the example from: https://ator1699.home.xs4all.nl/Work/GBS/Doc_and_download/doc/metrics.html#STST1
+        code = """
+        void stst( void )
+        {
+            int i;          /* 1 */
+        label_1:            /* 2 */
+        label_2:            /* 3 */
+            switch ( 1 )    /* 4 */
+            {               /* 5 */
+            case 0:         /* 6 */
+            case 1:         /* 7 */
+            case 2:         /* 8 */
+            default:        /* 9 */
+                break;      /* 10 */
+            }
+        }"""
+        result = get_cpp_function_list_with_extension(code, StatementCounter())
+        self.assertEqual(10, result[0].statement_count)

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -32,11 +32,9 @@ class TestCSVOutput(StreamStdoutTestCase):
         extension_mock.__class__.__name__ = 'LizardExtension'
         extension_mock.FUNCTION_INFO = {"exit_count": {"caption": "exits"}}
         options_mock.extensions = [extension_mock]
-
         results = AllResult([self.fileSummary])
         results.result[0].function_list[0].exit_count = 1
         csv_output(results, options_mock)
-
         self.assertRegexpMatches(sys.stdout.stream,
                                  r"NLOC,CCN,token,PARAM,length,location,file,function,long_name,start,end,exits")
 
@@ -68,8 +66,6 @@ class TestCSVOutput(StreamStdoutTestCase):
             sys.stdout.stream.splitlines()[0]
         )
 
-
-
     def test_print_fileinfo(self):
         options_mock = Mock()
         options_mock.verbose = True
@@ -77,10 +73,9 @@ class TestCSVOutput(StreamStdoutTestCase):
 
         self.foo.end_line = 100
         self.foo.cyclomatic_complexity = 16
-        fileStat = FileInformation("FILENAME", 1, [self.foo])
+        file_stat = FileInformation("FILENAME", 1, [self.foo])
 
-        csv_output(AllResult([fileStat]), options_mock)
-
+        csv_output(AllResult([file_stat]), options_mock)
         self.assertEqual(
             '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
             sys.stdout.stream.splitlines()[1]
@@ -93,9 +88,9 @@ class TestCSVOutput(StreamStdoutTestCase):
 
         self.foo.end_line = 100
         self.foo.cyclomatic_complexity = 16
-        fileStat = FileInformation("FILENAME", 1, [self.foo])
+        file_stat = FileInformation("FILENAME", 1, [self.foo])
 
-        csv_output(AllResult([fileStat]), options_mock)
+        csv_output(AllResult([file_stat]), options_mock)
 
         self.assertEqual(
             '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',

--- a/test/testOutputHTML.py
+++ b/test/testOutputHTML.py
@@ -18,4 +18,5 @@ class TestHTMLOutput(StreamStdoutTestCase):
     def test_should_have_html_body(self):
         html_output([self.fileSummary], self.option, None, AllResult)
         self.assertRegexpMatches(sys.stdout.stream,
-                r"\<html\>")
+                                 r"\<html\>")
+


### PR DESCRIPTION
See the following adjustments:

- Added suggestion of using the simplification as suggested by Terry Yin (if token == ";":... could be simplified as if token in [';', 'if',...].)
- Fixed problem of nested structures and cvs output (max_nested_structures not defined)
- Corrected Statement count
- Added some test code from the pages of Randy Marques. Below the mail that allows me to use the material as test code.
- On Tue, Sep 1, 2020 at 2:39 PM Randy Marques <Randy.Marques@xs4all.nl> wrote:
> Dear Patric, Thank you for your kind request. Very much appreciated. You are granted use op any part of the Generic Build Support documentation as longs as you mention the source. Good luck with your project. Randy Marques

Next to that I have some questions:
- the deprecated assertRegexpMatches cannot be replaced by assertRegex on python 2.7. Do you see another way?
- Python 2.7 has been "endofservice" since 1 januari 2020, see https://www.python.org/doc/sunset-python-2/. How long do you still want to support it?
- Does the implementation of lizardns.py solves [issue 202](https://github.com/terryyin/lizard/issues/202)
