### PR TITLE
add line_to_ccn={line:ccn}

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -285,6 +285,7 @@ class FunctionInfo(Nesting):  # pylint: disable=R0902
         self.fan_in = 0
         self.fan_out = 0
         self.general_fan_out = 0
+        self.line_to_ccn = {}
 
     @property
     def name_in_space(self):
@@ -463,6 +464,10 @@ class FileInfoBuilder(object):
 
     def add_condition(self, inc=1):
         self.current_function.cyclomatic_complexity += inc
+        if self.current_function.line_to_ccn.__contains__(self.current_line):
+            self.current_function.line_to_ccn[self.current_line] += inc
+        else:
+            self.current_function.line_to_ccn[self.current_line] = 1
 
     def add_to_long_function_name(self, app):
         self.current_function.add_to_long_name(app)

--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -38,7 +38,7 @@ def csv_output(result, options):
         for caption in extension_captions:
             extension_caption = "{},{}".format(extension_caption, caption)
         print("NLOC,CCN,token,PARAM,length,location,file,function," +
-              "long_name,start,end{}".format(extension_caption))
+              "long_name,start,end{},{{line:ccn}}".format(extension_caption))
 
     for source_file in result:
         if source_file:
@@ -49,7 +49,7 @@ def csv_output(result, options):
                         extension_string = '{},{}'.\
                             format(extension_string,
                                    source_function.__getattribute__(variable))
-                    print('{},{},{},{},{},"{}","{}","{}","{}",{},{}{}'.format(
+                    print('{},{},{},{},{},"{}","{}","{}","{}",{},{}{},"{}"'.format(
                         source_function.nloc,
                         source_function.cyclomatic_complexity,
                         source_function.token_count,
@@ -66,5 +66,6 @@ def csv_output(result, options):
                         source_function.long_name.replace("\"", "'"),
                         source_function.start_line,
                         source_function.end_line,
-                        extension_string
+                        extension_string,
+                        str(source_function.line_to_ccn)
                     ))


### PR DESCRIPTION
helo~
I want a new field to show the relationship between line and cyclomatic complexity, like this: 
![image](https://user-images.githubusercontent.com/34933160/100823386-1576b180-348f-11eb-978b-ee7bbbc1f16c.png)
So I added a variable `line_to_ccn` in the `FunctionInfo` class,  to record lines of code and add up the ccn in `add_condition()`. 
I also output `line_to_ccn` in csv files.