### PR TITLE
Fix wrong variable name in html template

### DIFF
--- a/lizard_ext/htmloutput.py
+++ b/lizard_ext/htmloutput.py
@@ -137,10 +137,10 @@ Cyclomatic complexity
        <td class="value">{{ func.token_count }}</td>
     {% endif %}
 
-    {% if func.parameters|length > thresholds["parameter_count"] %}
-       <td class="greater-value">{{ func.parameters|length }}</td>
+    {% if func.full_parameters|length > thresholds["parameter_count"] %}
+       <td class="greater-value">{{ func.full_parameters|length }}</td>
     {% else %}
-       <td class="lesser-value">{{ func.parameters|length }}</td>
+       <td class="lesser-value">{{ func.full_parameters|length }}</td>
     {% endif %}
   </tr>
   {% endfor %}


### PR DESCRIPTION
Hi :wave: 
I noticed that all `Parameter count` columns in generated html files are always `0` as the following image.
This PR fixes the issue.
![image](https://user-images.githubusercontent.com/1256980/108991300-46a3fe00-76db-11eb-812c-6bc81bde0fca.png)

ref: https://github.com/terryyin/lizard/commit/4a5d8275521fc86e878c3f3f8a82e0e972d7aa3e