### PR TITLE
Python line break ccn

### DIFF
--- a/lizard_languages/script_language.py
+++ b/lizard_languages/script_language.py
@@ -14,7 +14,7 @@ class ScriptLanguageMixIn(object):
 
     @staticmethod
     def generate_common_tokens(source_code, addition, match_holder=None):
-        _until_end = r"(?:\\\n|[^\n])*"
+        _until_end = r"(?:[^\n])*"
         return CodeReader.generate_tokens(
             source_code,
             r"|\#" + _until_end + addition,

--- a/test/test_languages/testPython.py
+++ b/test/test_languages/testPython.py
@@ -182,6 +182,31 @@ class Test_parser_for_Python(unittest.TestCase):
         self.assertEqual("function1", functions[1].name)
         self.assertEqual(4, functions[1].end_line)
 
+    
+    def test_comment_line_break(self):
+        class namespace11:
+            def function1():
+                # This is a comment with a line break\
+                if IamOnEarth:
+                    return toMars()
+        functions = get_python_function_list(inspect.getsource(namespace11))
+        self.assertEqual(1, len(functions))
+        self.assertEqual("function1", functions[0].name)
+        self.assertEqual(2, functions[0].cyclomatic_complexity)
+        self.assertEqual(5, functions[0].end_line)
+
+    def test_line_break(self):
+        class namespace11:
+            def function1():
+                if IamOnEarth\
+                    or IamOnMoon:
+                    return toMars()
+        functions = get_python_function_list(inspect.getsource(namespace11))
+        self.assertEqual(1, len(functions))
+        self.assertEqual("function1", functions[0].name)
+        self.assertEqual(3, functions[0].cyclomatic_complexity)
+        self.assertEqual(5, functions[0].end_line)
+
     def xtest_one_line_functions(self):
         class namespace8:
             def a( ):pass


### PR DESCRIPTION
This PR adds a test case which tests the control structure after line break issue (#317).

The suggested fix is to remove the line break option from `_until_end` in the `ScriptLanguageMixIn`.