### PR TITLE
Added duplicate code extension to options and fixed typo in readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -152,7 +152,7 @@ Options
   -m, --modified        Calculate modified cyclomatic complexity number , which count a
                         switch/case with multiple cases as one CCN.
   -E EXTENSIONS, --extension EXTENSIONS
-                        User the extensions. The available extensions are: -Ecpre: it will ignore
+                        Use the extensions. The available extensions are: -Ecpre: it will ignore
                         code in the #else branch. -Ewordcount: count word frequencies and
                         generate tag cloud. -Eoutside: include the global code as one function.
                         -EIgnoreAssert: to ignore all code in assert. -ENS: count nested control

--- a/README.rst
+++ b/README.rst
@@ -156,7 +156,7 @@ Options
                         code in the #else branch. -Ewordcount: count word frequencies and
                         generate tag cloud. -Eoutside: include the global code as one function.
                         -EIgnoreAssert: to ignore all code in assert. -ENS: count nested control
-                        structures.
+                        structures. -Eduplicate: detect duplicate code.
   -s SORTING, --sort SORTING
                         Sort the warning with field. The field can be nloc,
                         cyclomatic_complexity, token_count, parameter_count, etc. Or an customized field.

--- a/lizard.py
+++ b/lizard.py
@@ -74,12 +74,13 @@ def analyze_files(files, threads=1, exts=None):
 
 def _extension_arg(parser):
     parser.add_argument("-E", "--extension",
-                        help='''User the extensions. The available extensions
+                        help='''Use the extensions. The available extensions
                         are: -Ecpre: it will ignore code in the #else branch.
                         -Ewordcount: count word frequencies and generate tag
                         cloud. -Eoutside: include the global code as one
-                        function.  -EIgnoreAssert: to ignore all code in
-                        assert. -ENS: count nested control structures.''',
+                        function. -EIgnoreAssert: to ignore all code in
+                        assert. -ENS: count nested control structures.
+                        -Eduplicate: detect duplicate code.''',
                         action="append",
                         dest="extensions",
                         default=[])


### PR DESCRIPTION
I could'nt find the duplicate code detector extension in the options so I added it.