### PR TITLE
Make length a property of FileInfo

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -281,7 +281,6 @@ class FunctionInfo(Nesting):  # pylint: disable=R0902
         self.full_parameters = []
         self.filename = filename
         self.top_nesting_level = -1
-        self.length = 0
         self.fan_in = 0
         self.fan_out = 0
         self.general_fan_out = 0
@@ -309,6 +308,10 @@ class FunctionInfo(Nesting):  # pylint: disable=R0902
         matches = [re.search(r'(\w+)(\s=.*)?$', f)
                    for f in self.full_parameters]
         return [m.group(1) for m in matches if m]
+
+    @property
+    def length(self):
+        return self.end_line - self.start_line + int(self.start_line != self.end_line)
 
     def add_to_function_name(self, app):
         self.name += app
@@ -438,8 +441,6 @@ class FileInfoBuilder(object):
         self.fileinfo.nloc += count
         self.current_function.nloc += count
         self.current_function.end_line = self.current_line
-        self.current_function.length = \
-            self.current_line - self.current_function.start_line + 1
         self.newline = count > 0
 
     def try_new_function(self, name):

--- a/lizard.py
+++ b/lizard.py
@@ -311,7 +311,7 @@ class FunctionInfo(Nesting):  # pylint: disable=R0902
 
     @property
     def length(self):
-        return self.end_line - self.start_line + int(self.start_line != self.end_line)
+        return self.end_line - self.start_line + 1
 
     def add_to_function_name(self, app):
         self.name += app

--- a/test/testOutput.py
+++ b/test/testOutput.py
@@ -39,7 +39,7 @@ class TestFunctionOutput(StreamStdoutTestCase):
         self.foo.cyclomatic_complexity = 16
         fileStat = FileInformation("FILENAME", 1, [self.foo])
         print_and_save_modules([fileStat],  self.scheme)
-        self.assertEqual("       1     16      1      0       0 foo@100-100@FILENAME", sys.stdout.stream.splitlines()[3])
+        self.assertEqual("       1     16      1      0       1 foo@100-100@FILENAME", sys.stdout.stream.splitlines()[3])
 
 
 class Ext(object):
@@ -70,7 +70,7 @@ class TestWarningOutput(StreamStdoutTestCase):
         fileSummary = FileInformation("FILENAME", 123, [self.foo])
         scheme = OutputScheme([Ext()])
         count = print_clang_style_warning([fileSummary], self.option, scheme, None)
-        self.assertIn("FILENAME:100: warning: foo has 1 NLOC, 30 CCN, 1 token, 0 PARAM, 0 length, 10 ND\n", sys.stdout.stream)
+        self.assertIn("FILENAME:100: warning: foo has 1 NLOC, 30 CCN, 1 token, 0 PARAM, 1 length, 10 ND\n", sys.stdout.stream)
         self.assertEqual(1, count)
 
     def test_sort_warning(self):

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -44,7 +44,7 @@ class TestCSVOutput(StreamStdoutTestCase):
         options_mock.extensions = []
         csv_output(AllResult([self.fileSummary]), options_mock)
         self.assertEqual(
-            '1,1,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
+            '1,1,1,0,1,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
             sys.stdout.stream.splitlines()[0]
         )
 
@@ -62,7 +62,7 @@ class TestCSVOutput(StreamStdoutTestCase):
         csv_output(results, options_mock)
 
         self.assertEqual(
-            '1,1,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100,1',
+            '1,1,1,0,1,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100,1',
             sys.stdout.stream.splitlines()[0]
         )
 
@@ -77,7 +77,7 @@ class TestCSVOutput(StreamStdoutTestCase):
 
         csv_output(AllResult([file_stat]), options_mock)
         self.assertEqual(
-            '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
+            '1,16,1,0,1,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
             sys.stdout.stream.splitlines()[1]
         )
 
@@ -93,6 +93,6 @@ class TestCSVOutput(StreamStdoutTestCase):
         csv_output(AllResult([file_stat]), options_mock)
 
         self.assertEqual(
-            '1,16,1,0,0,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
+            '1,16,1,0,1,"foo@100-100@FILENAME","FILENAME","foo","foo",100,100',
             sys.stdout.stream.splitlines()[1]
         )


### PR DESCRIPTION
Small simplification of `FunctionInfo`'s `length` in order to not care about it anywhere else during the parsing process.

`int(self.start_line != self.end_line)` only for consistency with equal start and end lines.