### PR TITLE
add GitHub URL for PyPi

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -67,6 +67,9 @@ setup(
         '''It works with Java, C/C++, JavaScript, Python, Ruby, Swift, Objective C. Metrics includes cyclomatic complexity number etc.''',
     long_description=open('README.rst').read(),
     url='http://www.lizard.ws',
+    project_urls={
+        'Source': 'https://github.com/terryyin/lizard',
+    },
     download_url='https://pypi.python.org/lizard/',
     license='MIT',
     platforms='any',


### PR DESCRIPTION
Warehouse now uses the project_urls provided to display links in the sidebar on [this screen](https://pypi.org/project/requests/), as well as including them in API responses to help the automation tool find the source code for Requests.

Example: [pypi.org/pypi/requests/json](https://pypi.org/pypi/requests/json)
Docs: [packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls](https://packaging.python.org/en/latest/guides/distributing-packages-using-setuptools/#project-urls)