### PR TITLE
Fix incorrect python function end line when function declared with multiple lines

### DIFF
--- a/lizard_languages/python.py
+++ b/lizard_languages/python.py
@@ -53,7 +53,9 @@ class PythonReader(CodeReader, ScriptLanguageMixIn):
                         current_leading_spaces += count_spaces(token)
                     else:
                         if not token.startswith('#'):
-                            indents.set_nesting(current_leading_spaces, token)
+                            current_function = self.context.current_function
+                            if current_function.name == '*global*' or current_function.long_name.endswith(')'):
+                                indents.set_nesting(current_leading_spaces, token)
                         reading_leading_space = False
             else:
                 reading_leading_space = True

--- a/test/test_languages/testPython.py
+++ b/test/test_languages/testPython.py
@@ -105,10 +105,18 @@ class Test_parser_for_Python(unittest.TestCase):
             ):
                 if True:
                     return False
+
+            def foo3(arg1,
+                     arg2,
+                     arg3
+            ):
+                if True:
+                    return False
             """
         functions = get_python_function_list(source)
         self.assertEqual(6, functions[0].end_line)
         self.assertEqual(13, functions[1].end_line)
+        self.assertEqual(20, functions[2].end_line)
 
     def test_parameter_count(self):
         class namespace2:

--- a/test/test_languages/testPython.py
+++ b/test/test_languages/testPython.py
@@ -105,18 +105,35 @@ class Test_parser_for_Python(unittest.TestCase):
             ):
                 if True:
                     return False
-
-            def foo3(arg1,
-                     arg2,
-                     arg3
-            ):
-                if True:
-                    return False
             """
         functions = get_python_function_list(source)
         self.assertEqual(6, functions[0].end_line)
         self.assertEqual(13, functions[1].end_line)
-        self.assertEqual(20, functions[2].end_line)
+
+    def test_multi_line_function_def_with_indentation_more_than_function_body(self):
+        def function(arg1,
+                     arg2
+                     ):
+            if True:
+                return False
+
+        functions = get_python_function_list(inspect.getsource(function))
+        self.assertEqual(5, functions[0].nloc)
+        self.assertEqual(5, functions[0].end_line)
+
+    def test_function_surrounded_by_global_statements(self):
+        source = """
+        s1 = 'global statement'
+        def function(arg1,
+                     arg2
+                     ):
+            if True:
+                return False
+        s2 = 'global statement'
+        """
+        functions = get_python_function_list(source)
+        self.assertEqual(5, functions[0].nloc)
+        self.assertEqual(7, functions[0].end_line)
 
     def test_parameter_count(self):
         class namespace2:


### PR DESCRIPTION
fix issue #292 

In a multi-line function declaration, if a subsequent line is indented much more than the first line, it will result in the wrong end line of the function.

Example:
```
def foo(arg1,
        arg2,
        arg3
):
    if True:
        return
# old: 4 now: 6
```