### PR TITLE
Add "--short" option, print in warnings in red or green

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -29,6 +29,8 @@ import os
 from fnmatch import fnmatch
 import hashlib
 
+import specialTermPrint
+
 if sys.version[0] == '2':
     from future_builtins import map, filter  # pylint: disable=W0622, F0401
 
@@ -116,6 +118,11 @@ def arg_parser(prog=None):
                         action="store_true",
                         dest="verbose",
                         default=False)
+    parser.add_argument("--short",
+                        help="Output only warnings and total summary",
+                        action="store_false",
+                        dest="short",
+                        default=True)
     parser.add_argument("-C", "--CCN",
                         help='''Threshold for cyclomatic complexity number
                         warning. The default value is %d.
@@ -622,6 +629,25 @@ def whitelist_filter(warnings, script=None, whitelist=None):
             yield warning
 
 
+class AllResult(object):
+    def __init__(self, result):
+        self.result = list(file_info for file_info in result if file_info)
+        self.all_fun = list(itertools.chain(*(file_info.function_list
+                                            for file_info in self.result)))
+
+    def function_count(self):
+        return len(self.all_fun) or 1
+
+    def nloc_in_functions(self):
+        return sum([f.nloc for f in self.all_fun]) or 1
+
+    def as_fileinfo(self):
+        return FileInformation(
+                    "",
+                    sum([f.nloc for f in self.result]),
+                    self.all_fun)
+
+
 class OutputScheme(object):
     '''
     Collect the schema of the data columns.
@@ -734,48 +760,78 @@ class OutputScheme(object):
                 ]))
 
 
+def save_modules(all_fileinfos):
+    saved_fileinfos = []
+
+    for module_info in all_fileinfos:
+        if module_info:
+            saved_fileinfos.append(module_info)
+
+    return saved_fileinfos
+
+
+def print_modules(saved_fileinfos, scheme):
+    # Print function info
+    print(scheme.function_info_head())
+    for module_info in saved_fileinfos:
+        for fun in module_info.function_list:
+            try:
+                print(scheme.function_info(fun))
+            except UnicodeEncodeError:
+                print("Found ill-formatted unicode function name.")
+
+    ## Print module info
+    print(f"{len(saved_fileinfos)} file analyzed.")
+    print("==============================================================")
+    print("NLOC   " + scheme.average_captions() + " function_cnt    file")
+    print("--------------------------------------------------------------")
+    for module_info in saved_fileinfos:
+        print((
+            "{module.nloc:7d}" +
+            scheme.average_formatter() +
+            "{function_count:10d}" +
+            "     {module.filename}").format(
+                module=module_info,
+                function_count=len(module_info.function_list)))
+
+
+def get_warnings(code_infos, option):
+    warnings = whitelist_filter(warning_filter(option, code_infos),
+                                whitelist=option.whitelist)
+    if isinstance(option.sorting, list) and option.sorting:
+        warnings = sorted(warnings, reverse=True, key=lambda x: getattr(
+            x, option.sorting[0]))
+    return warnings
+
+
+def print_no_warnings(option):
+    warn_str = specialTermPrint.green_bold_str(
+        "No thresholds exceeded ({0})".format(
+            ' or '.join("{0} > {1}".format(
+                k, val) for k, val in option.thresholds.items())))
+
+    print("=" * len(warn_str) + "\n" + warn_str)
+
+
 def print_warnings(option, scheme, warnings):
     warning_count = 0
     warning_nloc = 0
-    warn_str = "!!!! Warnings ({0}) !!!!".format(
-        ' or '.join("{0} > {1}".format(
-            k, val) for k, val in option.thresholds.items()))
+    warn_str = specialTermPrint.red_bold_str(
+        "!!!! Warnings ({0}) !!!!".format(
+            ' or '.join("{0} > {1}".format(
+                k, val) for k, val in option.thresholds.items())))
+
     for warning in warnings:
         if warning_count == 0:
-            print("\n" + "=" * len(warn_str) + "\n" + warn_str)
+            print("=" * len(warn_str) + "\n" + warn_str)
             print(scheme.function_info_head())
         warning_count += 1
         warning_nloc += warning.nloc
         print(scheme.function_info(warning))
     if warning_count == 0:
         print_no_warnings(option)
+
     return warning_count, warning_nloc
-
-
-def print_no_warnings(option):
-    warn_str = "No thresholds exceeded ({0})".format(
-        ' or '.join("{0} > {1}".format(
-            k, val) for k, val in option.thresholds.items()))
-    print("\n" + "=" * len(warn_str) + "\n" + warn_str)
-
-
-class AllResult(object):
-    def __init__(self, result):
-        self.result = list(file_info for file_info in result if file_info)
-        self.all_fun = list(itertools.chain(*(file_info.function_list
-                                            for file_info in self.result)))
-
-    def function_count(self):
-        return len(self.all_fun) or 1
-
-    def nloc_in_functions(self):
-        return sum([f.nloc for f in self.all_fun]) or 1
-
-    def as_fileinfo(self):
-        return FileInformation(
-                    "",
-                    sum([f.nloc for f in self.result]),
-                    self.all_fun)
 
 
 def print_total(warning_count, warning_nloc, all_result, scheme):
@@ -795,46 +851,15 @@ def print_total(warning_count, warning_nloc, all_result, scheme):
                   nloc_rate=(warning_nloc/all_result.nloc_in_functions())))
 
 
-def print_and_save_modules(all_fileinfos, scheme):
-    saved_fileinfos = []
-    print(scheme.function_info_head())
-    for module_info in all_fileinfos:
-        if module_info:
-            saved_fileinfos.append(module_info)
-            for fun in module_info.function_list:
-                try:
-                    print(scheme.function_info(fun))
-                except UnicodeEncodeError:
-                    print("Found ill-formatted unicode function name.")
-    print("%d file analyzed." % (len(saved_fileinfos)))
-    print("==============================================================")
-    print("NLOC   " + scheme.average_captions() + " function_cnt    file")
-    print("--------------------------------------------------------------")
-    for module_info in saved_fileinfos:
-        print((
-            "{module.nloc:7d}" +
-            scheme.average_formatter() +
-            "{function_count:10d}" +
-            "     {module.filename}").format(
-            module=module_info,
-            function_count=len(module_info.function_list)))
-    return saved_fileinfos
-
-
-def get_warnings(code_infos, option):
-    warnings = whitelist_filter(warning_filter(option, code_infos),
-                                whitelist=option.whitelist)
-    if isinstance(option.sorting, list) and option.sorting:
-        warnings = sorted(warnings, reverse=True, key=lambda x: getattr(
-            x, option.sorting[0]))
-    return warnings
-
-
 def print_result(result, option, scheme, total_factory):
-    result = print_and_save_modules(result, scheme)
+    result = save_modules(result)
     warnings = get_warnings(result, option)
+
+    if option.short:
+        print_modules(result, scheme)
     warning_count, warning_nloc = print_warnings(option, scheme, warnings)
     print_total(warning_count, warning_nloc, total_factory(result), scheme)
+
     return warning_count
 
 

--- a/specialTermPrint.py
+++ b/specialTermPrint.py
@@ -1,0 +1,37 @@
+"""
+Special terminal printing options (bold, red, green...)
+"""
+
+
+color = {
+    "PURPLE": '\033[95m',
+    "CYAN": '\033[96m',
+    "DARKCYAN": '\033[36m',
+    "BLUE": '\033[94m',
+    "GREEN": '\033[92m',
+    "YELLOW": '\033[93m',
+    "RED": '\033[91m',
+    "BOLD": '\033[1m',
+    "UNDERLINE": '\033[4m',
+    "END": '\033[0m',
+}
+
+
+def bold_str(string: str) -> str:
+    return color["BOLD"] + string + color["END"]
+
+
+def red_str(string: str) -> str:
+    return color["RED"] + string + color["END"]
+
+
+def green_str(string: str) -> str:
+    return color["GREEN"] + string + color["END"]
+
+
+def red_bold_str(string: str) -> str:
+    return bold_str(red_str(string))
+
+
+def green_bold_str(string: str) -> str:
+    return bold_str(green_str(string))

--- a/test/testOutput.py
+++ b/test/testOutput.py
@@ -3,7 +3,7 @@ import sys
 from mock import Mock, patch
 from test.helper_stream import StreamStdoutTestCase
 import os
-from lizard import print_warnings, print_and_save_modules, FunctionInfo, FileInformation,\
+from lizard import print_warnings, save_modules, print_modules, FunctionInfo, FileInformation,\
     print_result, print_extension_results, get_extensions, OutputScheme, get_warnings, print_clang_style_warning,\
     parse_args, AllResult
 from lizard_ext import xml_output
@@ -20,25 +20,29 @@ class TestFunctionOutput(StreamStdoutTestCase):
         self.foo = FunctionInfo("foo", 'FILENAME', 100)
 
     def test_function_info_header_should_have_a_box(self):
-        print_and_save_modules([],  self.scheme)
+        result = save_modules([])
+        print_modules(result,  self.scheme)
         self.assertIn("=" * 20, sys.stdout.stream.splitlines()[0])
 
     def test_function_info_header_should_have_the_captions(self):
-        print_and_save_modules([],  self.scheme)
+        result = save_modules([])
+        print_modules(result,  self.scheme)
         self.assertEqual("  NLOC    CCN   token  PARAM  length  location  ", sys.stdout.stream.splitlines()[1])
 
     def test_function_info_header_should_have_the_captions_of_external_extensions(self):
         external_extension = Mock(FUNCTION_INFO = {"xx": {"caption":"*external_extension*"}}, ordering_index=-1)
         extensions = get_extensions([external_extension])
         scheme = OutputScheme(extensions)
-        print_and_save_modules([],  scheme)
+        result = save_modules([])
+        print_modules(result,  scheme)
         self.assertEqual("  NLOC    CCN   token  PARAM  length *external_extension* location  ", sys.stdout.stream.splitlines()[1])
 
     def test_print_fileinfo(self):
         self.foo.end_line = 100
         self.foo.cyclomatic_complexity = 16
         fileStat = FileInformation("FILENAME", 1, [self.foo])
-        print_and_save_modules([fileStat],  self.scheme)
+        result = save_modules([fileStat])
+        print_modules(result,  self.scheme)
         self.assertEqual("       1     16      1      0       1 foo@100-100@FILENAME", sys.stdout.stream.splitlines()[3])
 
 
@@ -92,22 +96,24 @@ class TestFileInformationOutput(StreamStdoutTestCase):
     def test_print_and_save_detail_information(self):
         scheme = OutputScheme([])
         fileSummary = FileInformation("FILENAME", 123, [])
-        print_and_save_modules([fileSummary], scheme)
+        result = save_modules([fileSummary])
+        print_modules(result, scheme)
         self.assertIn("    123       0.0     0.0        0.0         0     FILENAME\n", sys.stdout.stream)
 
     def test_print_and_save_detail_information_with_ext(self):
         scheme = OutputScheme([Ext()])
         fileSummary = FileInformation("FILENAME", 123, [])
-        print_and_save_modules([fileSummary], scheme)
+        result = save_modules([fileSummary])
+        print_modules(result, scheme)
         self.assertIn("Avg.ND", sys.stdout.stream)
         self.assertIn("    123       0.0     0.0        0.0     0.0         0     FILENAME", sys.stdout.stream)
 
 
     def test_print_file_summary_only_once(self):
         scheme = OutputScheme([])
-        print_and_save_modules(
-                            [FileInformation("FILENAME1", 123, []),
-                             FileInformation("FILENAME2", 123, [])], scheme)
+        result = save_modules([FileInformation("FILENAME1", 123, []),
+                             FileInformation("FILENAME2", 123, [])])
+        print_modules(result, scheme)
         self.assertEqual(1, sys.stdout.stream.count("FILENAME1"))
 
 

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -3,8 +3,8 @@ import unittest
 import sys
 from lizard_ext import csv_output
 from test.helper_stream import StreamStdoutTestCase
-from lizard import parse_args, print_and_save_modules, FunctionInfo, FileInformation,\
-    get_extensions, OutputScheme, AllResult
+from lizard import parse_args, FunctionInfo, FileInformation, get_extensions,\
+    OutputScheme, AllResult
 
 
 class TestCSVOutput(StreamStdoutTestCase):


### PR DESCRIPTION
1. Add "--short" option prints only warnings and total summary.

2. Print warnings string:
- red (threshold exceeded) - `!!!! Warnings (cyclomatic_complexity > 15 or length > 1000 or nloc > 1000000 or parameter_count > 100) !!!!`
  (problematic functions are not printed in red)
- green (no threshold exceeded) - `No thresholds exceeded (cyclomatic_complexity > 15 or length > 1000 or nloc > 1000000 or parameter_count > 100)`