### PR TITLE
fix: Correct parameter count for python function with trailing comma and parameterized type hints

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -301,11 +301,17 @@ class FunctionInfo(Nesting):  # pylint: disable=R0902
                         " %(name)s@%(start_line)s-%(end_line)s@%(filename)s"
                         % self.__dict__)
 
-    parameter_count = property(lambda self: len(self.full_parameters))
+    parameter_count = property(lambda self: len(self.parameters))
 
     @property
     def parameters(self):
-        matches = [re.search(r'(\w+)(\s=.*)?$', f)
+        # Exclude empty tokens as parameters. These can occur in languages
+        # allowing a trailing comma on the last parameter in an function
+        # argument list.
+        # Regex matches the parameter name, then optionally:
+        # - a default value given after an '=' sign
+        # - a type annotation given after a ':'
+        matches = [re.search(r'(\w+)(\s=.*)?(\s:.*)?$', f)
                    for f in self.full_parameters]
         return [m.group(1) for m in matches if m]
 

--- a/lizard_languages/python.py
+++ b/lizard_languages/python.py
@@ -84,6 +84,8 @@ class PythonStates(CodeStateMachine):  # pylint: disable=R0903
     def _dec(self, token):
         if token == ')':
             self._state = self._state_colon
+        elif token == '[':
+            self._state = self._state_parameterized_type_annotation
         else:
             self.context.parameter(token)
             return
@@ -100,3 +102,8 @@ class PythonStates(CodeStateMachine):  # pylint: disable=R0903
         if token.startswith('"""') or token.startswith("'''"):
             self.context.add_nloc(-token.count('\n') - 1)
         self._state_global(token)
+
+    def _state_parameterized_type_annotation(self, token):
+        self.context.add_to_long_function_name(" " + token)
+        if token == ']':
+            self._state = self._dec

--- a/test/test_languages/testPython.py
+++ b/test/test_languages/testPython.py
@@ -149,6 +149,62 @@ class Test_parser_for_Python(unittest.TestCase):
         functions = get_python_function_list(inspect.getsource(namespace_df))
         self.assertEqual(2, functions[0].parameter_count)
         self.assertEqual(['a', 'b'], functions[0].parameters)
+        self.assertEqual("function_with_2_parameters_and_default_value( a , b = None )",
+                         functions[0].long_name)
+
+    def test_parameter_count_with_type_annotations(self):
+        functions = get_python_function_list('''
+            def function_with_3_parameters(a: str, b: int, c: float):
+                pass
+        ''')
+        self.assertEqual(1, len(functions))
+        self.assertEqual(3, functions[0].parameter_count)
+        self.assertEqual(['a', 'b', 'c'], functions[0].parameters)
+        self.assertEqual("function_with_3_parameters( a : str , b : int , c : float )",
+                         functions[0].long_name)
+
+    def test_parameter_count_with_type_annotation_and_default(self):
+        functions = get_python_function_list('''
+            def function_with_3_parameters(a: int = 1):
+                pass
+        ''')
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].parameter_count)
+        self.assertEqual(['a'], functions[0].parameters)
+        self.assertEqual("function_with_3_parameters( a : int = 1 )",
+                         functions[0].long_name)
+
+    def test_parameter_count_with_parameterized_type_annotations(self):
+        functions = get_python_function_list('''
+            def function_with_parameterized_parameter(a: dict[str, tuple[int, float]]):
+                pass
+            def function_with_3_parameterized_parameters(a: dict[str, int],
+                                                         b: list[float],
+                                                         c: tuple[int, float, str]
+                                                         ):
+                pass
+                
+        ''')
+        self.assertEqual(2, len(functions))
+        self.assertEqual(1, functions[0].parameter_count)
+        self.assertEqual(['a'], functions[0].parameters)
+        self.assertEqual("function_with_parameterized_parameter( a : dict [ str , tuple [ int , float ] ] )",
+                         functions[0].long_name)
+        self.assertEqual(3, functions[1].parameter_count)
+        self.assertEqual(['a', 'b', 'c'], functions[1].parameters)
+        self.assertEqual("function_with_3_parameterized_parameters( a : dict [ str , int ] , b : list [ float ] , c : tuple [ int , float , str ] )",
+                         functions[1].long_name)
+
+    def test_parameter_count_with_trailing_comma(self):
+        functions = get_python_function_list('''
+            def foo(arg1,
+                    arg2,
+                    ):
+                # comment
+                return True
+        ''')
+        self.assertEqual(2, functions[0].parameter_count)
+        self.assertEqual(['arg1', 'arg2'], functions[0].parameters)
 
     def test_function_end(self):
         class namespace3:


### PR DESCRIPTION
Addresses https://github.com/terryyin/lizard/issues/354

In several situations, the argument count reported for python is incorrect. In particular:
- When a trailing comma is included in a function argument list
- When a parameterized type hint is provided that includes commas, e.g. dict[str, tuple[int, float]]

Below is a code snippet that reproduces these issues:

```python
def func_with_trailing_comma(
    a,
    b,
    c,
):
    pass


def func_with_type_parameterized_args(a: dict[str, tuple[int, float]]):
    pass
```

Running `lizard -a 2 demo.py` on this reports the following:
```
================================================
  NLOC    CCN   token  PARAM  length  location  
------------------------------------------------
       6      1     11      4       6 func_with_trailing_comma@1-6@demo.py
       2      1     18      3       2 func_with_type_parameterized_args@9-10@demo.py
1 file analyzed.
==============================================================
NLOC    Avg.NLOC  AvgCCN  Avg.token  function_cnt    file
--------------------------------------------------------------
      8       4.0     1.0       14.5         2     demo.py

=========================================================================================================
!!!! Warnings (cyclomatic_complexity > 15 or length > 1000 or nloc > 1000000 or parameter_count > 2) !!!!
================================================
  NLOC    CCN   token  PARAM  length  location  
------------------------------------------------
       6      1     11      4       6 func_with_trailing_comma@1-6@demo.py
       2      1     18      3       2 func_with_type_parameterized_args@9-10@demo.py
==========================================================================================
Total nloc   Avg.NLOC  AvgCCN  Avg.token   Fun Cnt  Warning cnt   Fun Rt   nloc Rt
------------------------------------------------------------------------------------------
         8       4.0     1.0       14.5        2            2      1.00    1.00
```

The correct result is reported with the fixes included in the second commit of this branch:
```
================================================
  NLOC    CCN   token  PARAM  length  location  
------------------------------------------------
       6      1     11      3       6 func_with_trailing_comma@1-6@demo.py
       2      1     18      1       2 func_with_type_parameterized_args@9-10@demo.py
1 file analyzed.
==============================================================
NLOC    Avg.NLOC  AvgCCN  Avg.token  function_cnt    file
--------------------------------------------------------------
      8       4.0     1.0       14.5         2     demo.py

=========================================================================================================
!!!! Warnings (cyclomatic_complexity > 15 or nloc > 1000000 or length > 1000 or parameter_count > 2) !!!!
================================================
  NLOC    CCN   token  PARAM  length  location  
------------------------------------------------
       6      1     11      3       6 func_with_trailing_comma@1-6@demo.py
==========================================================================================
Total nloc   Avg.NLOC  AvgCCN  Avg.token   Fun Cnt  Warning cnt   Fun Rt   nloc Rt
------------------------------------------------------------------------------------------
         8       4.0     1.0       14.5        2            1      0.50    0.75
```

I have included tests in the first commit of this branch that reproduce the issue and check for the correct result