### PR TITLE
require pygments

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -95,6 +95,7 @@ setup(
     packages=['lizard_ext', 'lizard_languages'],
     #data_files=[('lizard_ext', [])],
     py_modules=['lizard'],
+    install_requires=['pygments'],
     entry_points={'console_scripts': ['lizard = lizard:main']},
     author='Terry Yin',
     author_email='terry@odd-e.com',


### PR DESCRIPTION
`erlang.py` requires `pygments`, so make it a requirement of the project.

Resolves https://github.com/terryyin/lizard/issues/392