### PR TITLE
Fix file reading failure on non-UTF-8 Windows for BOM UTF-8 encoded whitelist and .gitignore files

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -623,7 +623,7 @@ def whitelist_filter(warnings, script=None, whitelist=None):
 
     def get_whitelist(whitelist):
         if os.path.isfile(whitelist):
-            return open(whitelist, mode='r').read()
+            return auto_read(whitelist)
         if whitelist != DEFAULT_WHITELIST:
             print("WARNING: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!")
             print("WARNING: the whitelist \""+whitelist+"\" doesn't exist.")
@@ -923,12 +923,12 @@ def get_all_source_files(paths, exclude_patterns, lans):
             for path in paths:
                 gitignore_path = os.path.join(path, '.gitignore')
                 if os.path.exists(gitignore_path):
-                    with open(gitignore_path, 'r') as gitignore_file:
-                        # Read lines and strip whitespace and empty lines
-                        patterns = [line.strip() for line in gitignore_file.readlines()]
-                        patterns = [p for p in patterns if p and not p.startswith('#')]
-                        gitignore_spec = pathspec.PathSpec.from_lines('gitwildmatch', patterns)
-                        base_path = path
+                    gitignore_file = auto_read(gitignore_path)
+                    # Read lines and strip whitespace and empty lines
+                    patterns = [line.strip() for line in gitignore_file.splitlines()]
+                    patterns = [p for p in patterns if p and not p.startswith('#')]
+                    gitignore_spec = pathspec.PathSpec.from_lines('gitwildmatch', patterns)
+                    base_path = path
                     break
         except ImportError:
             pass

--- a/test/testFilesFilter.py
+++ b/test/testFilesFilter.py
@@ -130,8 +130,8 @@ class TestFilesFilter(unittest.TestCase):
     @patch.object(os.path, "exists")
     @patch.object(os.path, "relpath")
     @patch.object(os, "walk")
-    @patch("builtins.open", create=True)
-    def test_gitignore_filter(self, mock_open, mock_os_walk, mock_relpath, mock_exists):
+    @patch("lizard.auto_read")
+    def test_gitignore_filter(self, mock_auto_read, mock_os_walk, mock_relpath, mock_exists):
         mock_os_walk.return_value = (['.',
                                     None,
                                     ['temp.c', 'node_modules/file.js', 'useful.cpp']], )
@@ -147,9 +147,7 @@ class TestFilesFilter(unittest.TestCase):
             return path.replace(os.sep, '/')
         mock_relpath.side_effect = relpath_side_effect
         
-        mock_file = mock_open.return_value.__enter__.return_value
-        mock_file.readlines.return_value = ["node_modules/\n", "*.c\n"]
-        mock_file.read.return_value = "node_modules/\n*.c\n"
+        mock_auto_read.return_value = "node_modules/\n*.c\n"
         
         files = get_all_source_files(["dir"], [], [])
         if which_system() == "Windows":

--- a/test/testOutput.py
+++ b/test/testOutput.py
@@ -143,12 +143,12 @@ class TestAllOutput(StreamStdoutTestCase):
         self.assertEqual(0, print_result_with_scheme(file_infos, option))
 
     @patch.object(os.path, 'isfile')
-    @patch('lizard.open', create=True)
-    def check_whitelist(self, script, mock_open, mock_isfile):
+    @patch('lizard.auto_read')
+    def check_whitelist(self, script, mock_auto_read, mock_isfile):
         mock_isfile.return_value = True
-        mock_open.return_value.read.return_value = script
+        mock_auto_read.return_value = script
         file_infos = [FileInformation('f1.c', 1, [self.foo])]
-        option = Mock(thresholds={'cyclomatic_complexity':15, 'length':1000}, CCN=15, number = 0, arguments=100, length=1000, extensions=[])
+        option = Mock(thresholds={'cyclomatic_complexity':15, 'length':1000}, CCN=15, number = 0, arguments=100, length=1000, extensions=[], whitelist='whitelist.txt')
         return print_result_with_scheme(file_infos, option)
 
     def test_exit_with_non_zero_when_more_warning_than_ignored_number(self):


### PR DESCRIPTION
On Windows systems where the default encoding is not UTF-8 (e.g., Japanese cp932), reading UTF-8 BOM files may fail if the encoding is not explicitly specified in the open() function.

## Root Cause
The open() function was called without specifying the encoding, which can lead to failures when reading UTF-8 BOM files on Windows systems with non-UTF-8 defaults like cp932.

## Solution
- Replaced direct file reading with `auto_read()` function for `.gitignore` processing
- Applied same fix to `.whitelizard.txt` file reading
- `auto_read()` function automatically detects and handles UTF-8 BOM files, providing consistent file reading across the codebase

## Testing
Verified successful file reading on both Windows and Ubuntu (WSL) environments with UTF-8 files both with and without BOM.

Also verified behavior when the file does not exist.

Updated test mocks to reflect the replacement of open() with auto_read().

Since a mock object was being passed to the function as a file path, added a whitelist attribute to the mock object for compatibility.

---
``` powershell
(venv) PS D:\dev\lizard> python.exe .\lizard.py
Traceback (most recent call last):
  File "D:\dev\lizard\lizard.py", line 1122, in <module>
    main()
    ~~~~^^
  File "D:\dev\lizard\lizard.py", line 1085, in main
    result = analyze(
        options.paths,
    ...<2 lines>...
        options.extensions,
        options.languages)
  File "D:\dev\lizard\lizard.py", line 62, in analyze
    files = get_all_source_files(paths, exclude_pattern, lans)
  File "D:\dev\lizard\lizard.py", line 969, in get_all_source_files
    _load_gitignore()
    ~~~~~~~~~~~~~~~^^
  File "D:\dev\lizard\lizard.py", line 928, in _load_gitignore
    patterns = [line.strip() for line in gitignore_file.readlines()]
                                         ~~~~~~~~~~~~~~~~~~~~~~~~^^
UnicodeDecodeError: 'cp932' codec can't decode byte 0xef in position 0: illegal multibyte sequence
```
Note: This description was translated and refined using ChatGPT.