### PR TITLE
Rust: correctly interpret lifetimes, labels

### DIFF
--- a/lizard_languages/rust.py
+++ b/lizard_languages/rust.py
@@ -19,6 +19,11 @@ class RustReader(CodeReader, CCppCommentsMixin):
         super().__init__(context)
         self.parallel_states = [RustStates(context)]
 
+    @staticmethod
+    def generate_tokens(source_code, addition='', token_class=None):
+        addition = r"|(?:'\w+\b)"  # lifetimes, labels
+        return CodeReader.generate_tokens(source_code, addition, token_class)
+
 
 class RustStates(GoLikeStates):  # pylint: disable=R0903
     FUNC_KEYWORD = 'fn'

--- a/test/test_languages/testRust.py
+++ b/test/test_languages/testRust.py
@@ -84,3 +84,13 @@ class TestRust(unittest.TestCase):
         }
         ''')
         self.assertEqual(2, len(result))
+
+    def test_lifetime(self):
+        result = get_rust_function_list('''
+        pub fn func<'a>(a: &'a i64)
+        {
+            _ = a
+        }
+        ''')
+
+        self.assertEqual(1, len(result))


### PR DESCRIPTION
Lizard interpreted two `'` signs as a string instead of a lifetime, hence the bug where the function would be omitted.