### PR TITLE
This change fixes an issue where the line count was incorrect when en…

### DIFF
--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -54,7 +54,7 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
                     elif macro.group(1) == 'include':
                         yield "#include"
                         yield macro.group(2) or "\"\""
-                    for _ in macro.group(2).splitlines()[1:]:
+                    for _ in macro.group(2).split('\n')[1:]:
                         yield '\n'
                 else:
                     yield token


### PR DESCRIPTION
…countering an empty line following a macro definition continuation marker.

Code to reproduce it.

```c
#define  SQ(x) ((x)*(x)) \

bool foo(status *pstat)
{
    return true;
}
```