### PR TITLE
refactor: Return exit codes from main() instead of calling sys.exit()

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -1109,7 +1109,8 @@ def main(argv=None):
         sys.stdout = original_stdout
         output_file.close()
     if 0 <= options.number < warning_count:
-        sys.exit(1)
+        return 1
+    return 0
 
 
 def print_extension_results(extensions):
@@ -1119,4 +1120,4 @@ def print_extension_results(extensions):
 
 
 if __name__ == "__main__":
-    main()
+    sys.exit(main())


### PR DESCRIPTION
Modified main() to return integer exit codes (0 for success, 1 for failure) rather than calling sys.exit() directly. The sys.exit() call is now only in the __main__ block.

This allows code to call main() with command line arguments without risking process termination, improving testability and enabling programmatic usage of the CLI functionality.

Follows Python best practices for structuring CLI entry points.