### PR TITLE
#442 : Handle 'use function' statements to prevent name overrides …

### DIFF
--- a/lizard_languages/php.py
+++ b/lizard_languages/php.py
@@ -29,13 +29,24 @@ class PHPLanguageStates(CodeStateMachine):
         self.assignments = []
         self.in_match = False
         self.match_case_count = 0
+        self.after_use = False
 
     def _state_global(self, token):
-        if token == 'class':
+        if token == 'use':
+            self.after_use = True
+        elif token == ';':
+            self.after_use = False
+        elif token == 'class':
+            self.after_use = False
             self._state = self._class_declaration
         elif token == 'trait':
+            self.after_use = False
             self._state = self._trait_declaration
         elif token == 'function':
+            if self.after_use:
+                # Skip 'use function ...' import statements
+                self.after_use = False
+                return
             self.is_function_declaration = True
             self._state = self._function_name
         elif token == 'fn':

--- a/test/test_languages/testPHP.py
+++ b/test/test_languages/testPHP.py
@@ -359,3 +359,20 @@ class NotebookApp {
         # Verify cyclomatic complexity for method with conditionals
         process_order = next(f for f in functions if f.name == 'Product::processOrder')
         self.assertEqual(7, process_order.cyclomatic_complexity)  # Current behavior shows 7 for this method
+
+    def test_use_function_does_not_override_first_function(self):
+        """Test that 'use function' import statements don't override actual function names.
+
+        Bug: https://github.com/terryyin/lizard/issues/442
+        """
+        php_code = '''<?php
+use function bar;
+class A {
+    function foo() {
+        return 1;
+    }
+}
+'''
+        functions = get_php_function_list(php_code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual('A::foo', functions[0].name)


### PR DESCRIPTION
Fixes #442 use function bar; import statements were being parsed as function declarations, causing the imported name to override the first actual function's name.