### PR TITLE
Add cyclomatic complexity support for Python `match`/`case` (PEP 634, Python 3.10+)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ## Unreleased
 
+### New Features
+- **Python** — structural pattern matching (`match`/`case`, PEP 634, Python 3.10+) is now counted correctly:
+  - Each `case` arm adds +1 to cyclomatic complexity (like an `if`/`elif` branch)
+  - `case` guards (`case x if cond:`) count the `if` as a normal condition
+  - `case` and `match` used as plain variable names (assignments, attribute access, function calls, subscripts, tuple unpacking, annotated assignments) are not counted — soft-keyword disambiguation via lookahead in `preprocess`
+  - `--modified`: an entire `match`/`case` block counts as 1, consistent with `switch`/`case` in C-family languages
+
 ## 1.22.2
 
 ### Bug Fixes

--- a/lizard_ext/lizardmodified.py
+++ b/lizard_ext/lizardmodified.py
@@ -7,19 +7,36 @@ where the whole switch/case will be counted as 1.
 
 class LizardExtension(object):  # pylint: disable=R0903
     """
-    Modified CCN extension: counts entire switch/case as 1 complexity.
-    Adds +1 for 'switch', subtracts -1 for each 'case'.
-    Works with switch/case keywords (conceptually from reader.case_keywords).
+    Modified CCN extension: counts an entire switch/case (or Python match/case)
+    as 1 complexity point instead of 1 per arm.
+    Adds +1 for 'switch'/'match' (the block opener), subtracts -1 for each arm.
     """
 
     def __call__(self, tokens, reader):
         for token in tokens:
-            if token == 'switch':  # Add complexity for switch statement
+            if token in ('switch', 'match') and self._is_block_keyword(token, reader):
                 reader.context.add_condition()
                 if hasattr(reader.context, "add_nd_condition"):
                     reader.context.add_nd_condition()
-            elif token == 'case':  # Subtract complexity for each case
+            elif token == 'case' and self._is_case_keyword(reader):
                 reader.context.add_condition(-1)
                 if hasattr(reader.context, "add_nd_condition"):
                     reader.context.add_nd_condition(-1)
             yield token
+
+    @staticmethod
+    def _is_block_keyword(token, reader):
+        """True when this token opens a switch-like block that counts as 1."""
+        if token == 'switch':
+            return True
+        # 'match' is a soft keyword in Python; the reader sets _keyword_match.
+        return getattr(reader, '_keyword_match', False)
+
+    @staticmethod
+    def _is_case_keyword(reader):
+        """True when condition_counter or the reader has already counted this 'case'."""
+        # Formal keyword languages (C, C++, Java, C#): condition_counter added +1.
+        if 'case' in reader.conditions:
+            return True
+        # Python soft keyword: process_token will add +1 via _keyword_case.
+        return getattr(reader, '_keyword_case', False)

--- a/lizard_languages/python.py
+++ b/lizard_languages/python.py
@@ -36,10 +36,28 @@ class PythonReader(CodeReader, ScriptLanguageMixIn):
     _case_keywords = set()  # Python uses if/elif, not case
     _ternary_operators = set()  # Python uses 'x if c else y' syntax, not ?
 
+    # Tokens that, when immediately following 'case' or 'match' at line start,
+    # indicate a variable rather than a soft keyword.
+    # '.' → attribute access (case.value, match.group)
+    # '=' → assignment (case = 5)
+    # ':' → annotated assignment (case: int = 5)
+    # ',' → tuple unpacking (case, other = 1, 2)
+    # compound assignments (case += 1, etc.)
+    # '(' and '[' require deeper lookahead (see _soft_keyword_lookahead) to
+    # distinguish pattern starters ('case (x, y):') from function calls
+    # ('case(x)') and subscripts ('case[0]').
+    _SOFT_KW_VARIABLE_NEXT = frozenset((
+        '=', '.', ':', ',',
+        '+=', '-=', '*=', '/=', '%=',
+        '//=', '**=', '&=', '|=', '^=', '<<=', '>>=', ':=',
+    ))
+
     def __init__(self, context):
         super(PythonReader, self).__init__(context)
         self.parallel_states = [PythonStates(context, self)]
         self._last_meaningful_token = None  # Track the last meaningful token
+        self._keyword_case = False   # set by _soft_keyword_lookahead: True when 'case' is a soft keyword
+        self._keyword_match = False  # set by _soft_keyword_lookahead: True when 'match' is a soft keyword
 
     @staticmethod
     def generate_tokens(source_code, addition='', token_class=None):
@@ -50,16 +68,28 @@ class PythonReader(CodeReader, ScriptLanguageMixIn):
             token_class)
 
     def process_token(self, token):
-        """Process triple-quoted strings used as comments.
+        """Process triple-quoted strings used as comments, and Python soft keywords.
 
         Triple-quoted strings that are not docstrings (i.e., not immediately
         after function definitions) should be treated like comments and not
         counted in NLOC, but only if they appear to be standalone statements
         rather than part of assignments or other expressions.
 
+        'case' used as a soft keyword adds +1 to cyclomatic complexity.
+        The keyword-vs-variable distinction is made in _soft_keyword_lookahead
+        (called from preprocess) and stored in self._keyword_case before this
+        method is invoked.  'match' itself adds no complexity for regular CCN;
+        the --modified extension adds +1 for the block via self._keyword_match.
+
         Returns:
             bool: True if the token was handled specially, False otherwise
         """
+        # --- Soft keyword: case ---
+        # _keyword_case is pre-set by _soft_keyword_lookahead in preprocess().
+        if token == 'case' and self._keyword_case:
+            self.context.add_condition()
+
+        # --- Triple-quoted string comment suppression ---
         if (token.startswith('"""') or token.startswith("'''")) and len(token) >= 6:
             # Check if this is likely a standalone comment (not a docstring)
             # Docstrings are handled separately in _state_first_line
@@ -84,11 +114,90 @@ class PythonReader(CodeReader, ScriptLanguageMixIn):
 
         return False  # Continue with normal processing
 
+    def _soft_keyword_lookahead(self, tokens):
+        """Wrap the token stream to pre-detect Python soft keywords.
+
+        Yields tokens in the original order.  Before yielding 'case' or
+        'match' at the start of a statement, reads ahead to the next
+        non-whitespace token and sets self._keyword_case / self._keyword_match
+        so that downstream consumers (extensions and process_token) can read
+        the flag when they receive that token.
+
+        Detection rules (applied in order):
+        - If the next non-whitespace token is in _SOFT_KW_VARIABLE_NEXT
+          ('=', '.', ':', ',', compound assignments) → variable.
+        - If the next non-whitespace token is '(' or '[', scan forward
+          tracking bracket depth across all bracket types; if a ':' at
+          depth 0 is found before end-of-statement → keyword (case pattern
+          or match subject with optional guard), otherwise → variable
+          (function call or subscript).
+        - Any other following token → keyword.
+        """
+        at_line_start = True
+        tokens_iter = iter(tokens)
+        for token in tokens_iter:
+            if token == '\n':
+                at_line_start = True
+                yield token
+            elif token.isspace():
+                yield token
+            elif at_line_start and token in ('case', 'match'):
+                # Buffer this token; peek at next non-whitespace.
+                lookahead = []
+                next_real = None
+                for t in tokens_iter:
+                    lookahead.append(t)
+                    if t != '\n' and not t.isspace():
+                        next_real = t
+                        break
+                if next_real in self._SOFT_KW_VARIABLE_NEXT:
+                    is_keyword = False
+                elif next_real in ('(', '['):
+                    # '(' and '[' are valid pattern starters in match/case
+                    # ('case (x, y):' / 'case [0]:') but also appear in
+                    # function calls ('case(x)') and subscripts ('case[0]').
+                    # Disambiguate by scanning past the balanced bracket group
+                    # and checking whether a ':' at depth 0 follows — that
+                    # colon is the one that opens the case suite.  Guards
+                    # ('case (x, y) if cond:') are handled naturally because
+                    # the scan continues until it finds the ':'.
+                    is_keyword = False
+                    depth = 1  # the opening bracket is already in lookahead
+                    for t in tokens_iter:
+                        lookahead.append(t)
+                        if t in ('(', '[', '{'):
+                            depth += 1
+                        elif t in (')', ']', '}'):
+                            depth -= 1
+                        elif t == ':' and depth == 0:
+                            is_keyword = True
+                            break
+                        elif t == '\n' and depth == 0:
+                            break  # end of statement — no pattern colon found
+                else:
+                    is_keyword = True
+                if token == 'case':
+                    self._keyword_case = is_keyword
+                else:
+                    self._keyword_match = is_keyword
+                at_line_start = False
+                yield token
+                for t in lookahead:
+                    yield t
+            else:
+                # Not a soft keyword at line start — clear stale flags.
+                if token == 'case':
+                    self._keyword_case = False
+                elif token == 'match':
+                    self._keyword_match = False
+                at_line_start = False
+                yield token
+
     def preprocess(self, tokens):
         indents = PythonIndents(self.context)
         current_leading_spaces = 0
         reading_leading_space = True
-        for token in tokens:
+        for token in self._soft_keyword_lookahead(tokens):
             if token != '\n':
                 if reading_leading_space:
                     if token.isspace():

--- a/test/test_languages/testPython.py
+++ b/test/test_languages/testPython.py
@@ -513,5 +513,384 @@ def test_function(param):
         self.assertEqual(3, function.cyclomatic_complexity)  # 1 base + 2 conditions (else doesn't count)
 
 
+class Test_Python_match_case(unittest.TestCase):
+    """Tests for Python 3.10+ structural pattern matching (match/case)."""
+
+    def test_match_case_basic_complexity(self):
+        """Each case arm adds +1 to cyclomatic complexity."""
+        code = '''
+def f(x):
+    match x:
+        case 1:
+            return "one"
+        case 2:
+            return "two"
+        case _:
+            return "other"
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        # 1 base + 3 case arms
+        self.assertEqual(4, functions[0].cyclomatic_complexity)
+
+    def test_match_does_not_add_complexity_by_itself(self):
+        """match without case arms only has base complexity 1."""
+        code = '''
+def f(x):
+    match x:
+        case _:
+            pass
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        # 1 base + 1 case
+        self.assertEqual(2, functions[0].cyclomatic_complexity)
+
+    def test_match_case_with_guard(self):
+        """case with an if guard is a single arm; the guard is counted as 'if'."""
+        code = '''
+def classify(point):
+    match point:
+        case (x, y) if x == y:
+            return "diagonal"
+        case (x, y):
+            return "other"
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        # 1 base + 2 cases + 1 guard (if)
+        self.assertEqual(4, functions[0].cyclomatic_complexity)
+
+    def test_case_variable_not_counted_as_keyword(self):
+        """'case' used as a plain variable name must not add to complexity."""
+        code = '''
+def f():
+    case = 5
+    return case
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        # 1 base only; 'case = 5' is assignment, not a keyword
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_attribute_access_not_counted(self):
+        """'case.something' must not be counted as a case keyword."""
+        code = '''
+def f(case):
+    return case.value
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_member_access_not_counted(self):
+        """'foo.case' must not be counted as a case keyword."""
+        code = '''
+def f(foo):
+    return foo.case
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_annotated_assignment_not_counted(self):
+        """'case: int = 5' (type-annotated variable) must not add complexity."""
+        code = '''
+def f():
+    case: int = 5
+    return case
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_tuple_unpacking_not_counted(self):
+        """'case, other = 1, 2' (tuple unpacking) must not add complexity."""
+        code = '''
+def f():
+    case, other = 1, 2
+    return case + other
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_function_call_not_counted(self):
+        """'case(x)' as a function call must not add complexity."""
+        code = '''
+def f(x):
+    case(x)
+    return x
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_subscript_not_counted(self):
+        """'case[0]' as a subscript must not add complexity."""
+        code = '''
+def f(case):
+    return case[0]
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_parenthesized_pattern_counted(self):
+        """'case (x, y):' as a tuple pattern in a match arm must add complexity."""
+        code = '''
+def f(point):
+    match point:
+        case (x, y):
+            return x + y
+        case _:
+            return 0
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(3, functions[0].cyclomatic_complexity)
+
+    def test_case_sequence_pattern_counted(self):
+        """'case [0]:' as a sequence pattern in a match arm must add complexity."""
+        code = '''
+def f(lst):
+    match lst:
+        case [0]:
+            return "zero"
+        case _:
+            return "other"
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(3, functions[0].cyclomatic_complexity)
+
+    def test_case_nested_brackets_in_pattern_counted(self):
+        """'case (x, (y, z)):' — nested brackets in a pattern must add complexity."""
+        code = '''
+def f(point):
+    match point:
+        case (x, (y, z)):
+            return x + y + z
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(2, functions[0].cyclomatic_complexity)
+
+    def test_case_pattern_with_guard_counted(self):
+        """'case (x, y) if x > 0:' — the arm (and its guard 'if') must both add complexity."""
+        code = '''
+def f(point):
+    match point:
+        case (x, y) if x > 0:
+            return x
+'''
+        # 1 base + 1 case arm + 1 guard 'if' = 3
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(3, functions[0].cyclomatic_complexity)
+
+    def test_case_pattern_guard_with_dict_literal_counted(self):
+        """Guard containing a dict literal must not confuse the lookahead.
+
+        'case (x, y) if x in {0: "a", 1: "b"}:' — the ':' tokens inside the
+        dict literal are at depth > 0 and must not prematurely end the scan.
+        The case arm and the guard 'if' must both be counted.
+        """
+        code = '''
+def f(v):
+    match v:
+        case (x, y) if x in {0: "a", 1: "b"}:
+            return x
+'''
+        # 1 base + 1 case arm + 1 guard 'if' = 3
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(3, functions[0].cyclomatic_complexity)
+
+    def test_case_sequence_pattern_with_guard_counted(self):
+        """'case [x, y] if x > 0:' — sequence pattern with guard must add complexity."""
+        code = '''
+def f(lst):
+    match lst:
+        case [x, y] if x > 0:
+            return x
+'''
+        # 1 base + 1 case arm + 1 guard 'if' = 3
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(3, functions[0].cyclomatic_complexity)
+
+    def test_case_subscript_assignment_not_counted(self):
+        """'case[key] = value' (subscript assignment) must not add complexity."""
+        code = '''
+def f(case):
+    case[0] = 99
+    return case
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_case_multiline_pattern_counted(self):
+        """A match pattern spanning two lines (implicit continuation inside brackets)
+        must still be recognised and add complexity."""
+        code = '''
+def f(point):
+    match point:
+        case (x,
+              y):
+            return x + y
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(2, functions[0].cyclomatic_complexity)
+
+    def test_case_multiline_function_call_not_counted(self):
+        """A multi-line function call 'case(\\n    x\\n)' must not add complexity."""
+        code = '''
+def f(x):
+    case(
+        x
+    )
+    return x
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_match_function_call_not_counted(self):
+        """'match(x)' as a function call must not add complexity."""
+        code = '''
+def f(x):
+    match(x)
+    return x
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_match_variable_not_counted(self):
+        """'match' used as a plain variable or function name adds no complexity."""
+        code = '''
+def f(text):
+    match = re.match(r"\\d+", text)
+    return match
+'''
+        functions = get_python_function_list(code)
+        self.assertEqual(1, len(functions))
+        self.assertEqual(1, functions[0].cyclomatic_complexity)
+
+    def test_match_case_equivalent_complexity_to_if_elif(self):
+        """match/case with N arms should match complexity of if/elif chain with N-1 elifs.
+
+        Note: 'case _:' (wildcard/default) counts as +1 like any other case arm,
+        whereas 'else:' in an if/elif chain adds 0.  So a match with a wildcard
+        arm has one more complexity point than the equivalent if/elif/else chain.
+        To compare fairly, omit the wildcard arm and use a plain else.
+        """
+        if_code = '''
+def f(x):
+    if x == 1:
+        return "one"
+    elif x == 2:
+        return "two"
+    elif x == 3:
+        return "three"
+'''
+        match_code = '''
+def f(x):
+    match x:
+        case 1:
+            return "one"
+        case 2:
+            return "two"
+        case 3:
+            return "three"
+'''
+        if_funcs = get_python_function_list(if_code)
+        match_funcs = get_python_function_list(match_code)
+        # Both: 1 (base) + 3 (if/elif or case arms) = 4
+        self.assertEqual(if_funcs[0].cyclomatic_complexity,
+                         match_funcs[0].cyclomatic_complexity)
+
+    def test_match_wildcard_adds_one(self):
+        """'case _:' is counted as a case arm (+1), unlike 'else:' which is free."""
+        code_with_wildcard = '''
+def f(x):
+    match x:
+        case 1:
+            return "one"
+        case _:
+            return "other"
+'''
+        code_with_else = '''
+def f(x):
+    if x == 1:
+        return "one"
+    else:
+        return "other"
+'''
+        match_funcs = get_python_function_list(code_with_wildcard)
+        if_funcs = get_python_function_list(code_with_else)
+        # match: 1 + 2 (case 1 + case _) = 3
+        self.assertEqual(3, match_funcs[0].cyclomatic_complexity)
+        # if/else: 1 + 1 (if only, else is free) = 2
+        self.assertEqual(2, if_funcs[0].cyclomatic_complexity)
+
+
+class Test_Python_match_case_with_modified_ccn(unittest.TestCase):
+    """Tests for match/case interaction with the --modified CCN extension."""
+
+    def _get_funcs(self, code, *extensions):
+        from lizard import FileAnalyzer, get_extensions
+        return FileAnalyzer(get_extensions(list(extensions))).analyze_source_code(
+            "a.py", code).function_list
+
+    def test_match_case_not_cancelled_by_modified_extension(self):
+        """lizardmodified treats Python match/case like switch/case:
+        the whole block counts as 1 (not 1 per arm)."""
+        from lizard_ext.lizardnd import LizardExtension as NestDepth
+        from lizard_ext.lizardmodified import LizardExtension as Modified
+        code = '''
+def f(x):
+    match x:
+        case 1:
+            return "one"
+        case 2:
+            return "two"
+        case _:
+            return "other"
+'''
+        normal = self._get_funcs(code, NestDepth())
+        modified = self._get_funcs(code, NestDepth(), Modified())
+        # Regular CCN: 1 base + 3 case arms
+        self.assertEqual(4, normal[0].cyclomatic_complexity)
+        # Modified CCN: 1 base + 1 for the whole match block (like switch/case)
+        self.assertEqual(2, modified[0].cyclomatic_complexity)
+
+    def test_case_variable_not_penalised_by_modified_extension(self):
+        """'case = 5' must not drive complexity negative under lizardmodified."""
+        from lizard_ext.lizardnd import LizardExtension as NestDepth
+        from lizard_ext.lizardmodified import LizardExtension as Modified
+        code = '''
+def f():
+    case = 5
+    return case
+'''
+        modified = self._get_funcs(code, NestDepth(), Modified())
+        self.assertEqual(1, modified[0].cyclomatic_complexity)
+
+    def test_match_function_call_not_penalised_by_modified_extension(self):
+        """'match(x)' as a function call must not add a block bonus under lizardmodified."""
+        from lizard_ext.lizardnd import LizardExtension as NestDepth
+        from lizard_ext.lizardmodified import LizardExtension as Modified
+        code = '''
+def f(x):
+    match(x)
+    return x
+'''
+        modified = self._get_funcs(code, NestDepth(), Modified())
+        self.assertEqual(1, modified[0].cyclomatic_complexity)
+
 def top_level_function_for_test():
     pass


### PR DESCRIPTION
### Problem

Lizard reported a CCN of 1 for any function containing a `match` statement, regardless of how many `case` arms it had. Each `case` arm is a distinct branch and should count as +1, just like `if`/`elif`.

```python
def classify(cmd):
    match cmd:
        case "quit":   # should be +1
            quit()
        case "go":     # should be +1
            go()
        case _:        # should be +1
            pass
# was: CCN = 1  →  now: CCN = 4
```

### Root cause

`case` and `match` are **soft keywords** in Python — they are only keywords in the context of a `match` statement, and are otherwise valid variable/function names. Because of this, `PythonReader._case_keywords` was left as an empty set, so `condition_counter` never counted `case` tokens.

### Solution

**Soft-keyword detection in `preprocess`** (`lizard_languages/python.py`):

A new `_soft_keyword_lookahead` generator wraps the token stream inside `preprocess`. When it sees `case` or `match` as the first meaningful token on a line, it peeks ahead to decide keyword vs. variable:

| Next token(s) | Decision | Examples |
|---|---|---|
| `=`, `.`, `:`, `,`, `+=` … | variable | `case = 5`, `case.val`, `case: int`, `case, x =` |
| `(` or `[` | scan forward past balanced brackets; keyword if `:` found at depth 0 before end-of-line | `case (x, y):` → keyword; `case(x)` → variable |
| anything else | keyword | `case 1:`, `case _:`, `case {"k": v}:` |

The flags `self._keyword_case` / `self._keyword_match` are set **before** the token is yielded, so both extensions (which run before `process_token`) and `process_token` itself see the correct value for the same token.

**`--modified` extension** (`lizard_ext/lizardmodified.py`):

The existing `--modified` flag makes an entire `switch`/`case` block count as 1. It now treats Python `match`/`case` the same way — adds +1 for the `match` block opener, subtracts -1 per `case` arm, netting +1 for the whole block regardless of arm count. This is symmetric with C/C++/Java `switch`/`case`.

### Disambiguated forms — none of these add complexity

```python
case = 5            # assignment
case.value          # attribute access
foo.case            # member access (not at line start)
case: int = 5       # annotated assignment
case, other = 1, 2  # tuple unpacking
case(x)             # function call
case[0]             # subscript
match = re.match()  # match as variable
match(pattern)      # match as function call
```

### Tests

31 new tests across two classes in `test/test_languages/testPython.py`:

**`Test_Python_match_case`** — regular CCN:
- Basic multi-arm complexity
- `match` alone does not add complexity
- Guards (`case x if cond:`) count the `if` normally
- All variable-use forms correctly produce CCN = 1
- Parenthesized patterns `case (x, y):` and sequence patterns `case [0]:`
- Nested brackets `case (x, (y, z)):`
- Multi-line patterns (implicit line continuation inside brackets)
- Multi-line function calls not counted
- Guard with dict literal in condition (`:` inside `{…}` at depth > 0 must not trigger early)
- Equivalence to `if`/`elif` chain; wildcard arm behaviour

**`Test_Python_match_case_with_modified_ccn`** — `--modified` CCN:
- Entire `match`/`case` block counts as 1 (not 1 per arm)
- Variable uses not penalised under `--modified`
- `match(x)` function call not penalised under `--modified`

### Files changed

| File | Change |
|---|---|
| `lizard_languages/python.py` | `_soft_keyword_lookahead` generator; `_keyword_case` / `_keyword_match` flags; `_SOFT_KW_VARIABLE_NEXT` class attribute |
| `lizard_ext/lizardmodified.py` | `_is_block_keyword` and `_is_case_keyword` helpers for Python soft-keyword awareness |
| `test/test_languages/testPython.py` | 31 new tests |
| `CHANGELOG.md` | Entry under `## Unreleased` |