### PR TITLE
fix(clike): C++ raw string literals swallow following functions (#478)

### DIFF
--- a/lizard_languages/clike.py
+++ b/lizard_languages/clike.py
@@ -32,10 +32,15 @@ class CLikeReader(CodeReader, CCppCommentsMixin):
 
     @staticmethod
     def generate_tokens(source_code, addition='', token_class=None):
-        # Add pattern for C++ raw string literals R"delimiter(content)delimiter"
-        # The delimiter can be empty or up to 16 chars (excluding parentheses, backslash, whitespace)
-        # Using a simplified pattern that handles most cases
-        addition = r"|R\"[^(\\]*\((?:[^)]|\)[^\"])*\)[^(\\]*\"" + \
+        # C++ raw string literals: R"(...)" with an optional encoding prefix
+        # (u8/u/U/L). Match the empty-delimiter form and stop at the first ')"'
+        # terminator: a ')' only continues the body when it is not followed by a
+        # double quote. The pattern added for #451 used a closing class of
+        # [^(\\]* which also matched '"', so it ran past the terminator and
+        # swallowed the following code (issue #478). Custom delimiters such as
+        # R"tag(...)tag" without an embedded '"' are handled by the normal
+        # string-literal rule that follows in the token pattern.
+        addition = r"|(?:u8|u|U|L)?R\"\((?:[^)]|\)(?!\"))*\)\"" + \
                   r"|(?:\d*\.\d+(?:[eE][-+]?\d+)?)" + \
                   r"|(?:\d+\.(?:\d+)?(?:[eE][-+]?\d+)?)" + \
                   addition

--- a/test/test_languages/testCAndCPP.py
+++ b/test/test_languages/testCAndCPP.py
@@ -795,3 +795,91 @@ void func3() {
         self.assertEqual("func1", result[0].name)
         self.assertEqual("func2", result[1].name)
         self.assertEqual("func3", result[2].name)
+
+
+class Test_cpp_raw_string_literals(unittest.TestCase):
+    """Issue #478: a C++ raw string literal must not corrupt function boundary
+    detection. The raw-string pattern added for #451 stopped a crash, but its
+    closing delimiter class also matched a double quote, so a raw string raced
+    past its terminator and swallowed the code that followed it."""
+
+    def test_raw_string_brace_init_keeps_following_function(self):
+        result = get_cpp_function_list(
+            'auto process()\n'
+            '{\n'
+            '    const auto r_pattern{R"(\\b\\w*R\\w*\\b)"};\n'
+            '    const auto e_pattern{R"(<Blah>(\\d+)</Blah>)"};\n'
+            '}\n'
+            '\n'
+            'int main()\n'
+            '{\n'
+            '    auto pat = "{}";\n'
+            '}\n')
+        self.assertEqual(2, len(result))
+        self.assertEqual("process", result[0].name)
+        self.assertEqual(1, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+        self.assertEqual("main", result[1].name)
+        self.assertEqual(7, result[1].start_line)
+        self.assertEqual(10, result[1].end_line)
+
+    def test_raw_string_eq_init_keeps_function_bounds(self):
+        result = get_cpp_function_list(
+            'auto process()\n'
+            '{\n'
+            '    const auto r_pattern = R"(\\b\\w*R\\w*\\b)";\n'
+            '    const auto e_pattern = R"(<Blah>(\\d+)</Blah>)";\n'
+            '}\n'
+            '\n'
+            'int main()\n'
+            '{\n'
+            '    auto pat = "{}";\n'
+            '}\n')
+        self.assertEqual(2, len(result))
+        self.assertEqual("process", result[0].name)
+        self.assertEqual(1, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+        self.assertEqual("main", result[1].name)
+        self.assertEqual(7, result[1].start_line)
+        self.assertEqual(10, result[1].end_line)
+
+    def test_raw_string_with_encoding_prefix(self):
+        result = get_cpp_function_list(
+            'int a()\n'
+            '{\n'
+            '    auto w = LR"(wide)";\n'
+            '    auto u = u8R"(utf8)";\n'
+            '}\n'
+            'int b()\n'
+            '{\n'
+            '    return 0;\n'
+            '}\n')
+        self.assertEqual(2, len(result))
+        self.assertEqual("a", result[0].name)
+        self.assertEqual(1, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+        self.assertEqual("b", result[1].name)
+        self.assertEqual(6, result[1].start_line)
+        self.assertEqual(9, result[1].end_line)
+
+    def test_custom_delimiter_raw_string_keeps_following_function(self):
+        # Custom delimiters are not matched by the raw-string pattern; they fall
+        # through to the normal string rule. That is fine as long as they carry
+        # no embedded double quote, which is the overwhelmingly common case
+        # (JSON/HTML bodies with balanced braces). Lock that boundary here.
+        result = get_cpp_function_list(
+            'int a()\n'
+            '{\n'
+            '    auto j = R"json({"x": [1, 2]})json";\n'
+            '}\n'
+            'int b()\n'
+            '{\n'
+            '    return 0;\n'
+            '}\n')
+        self.assertEqual(2, len(result))
+        self.assertEqual("a", result[0].name)
+        self.assertEqual(1, result[0].start_line)
+        self.assertEqual(4, result[0].end_line)
+        self.assertEqual("b", result[1].name)
+        self.assertEqual(5, result[1].start_line)
+        self.assertEqual(8, result[1].end_line)


### PR DESCRIPTION
## What

C++ raw string literals corrupt function boundary detection. Given:

```cpp
auto process()
{
    const auto r_pattern{R"(\b\w*R\w*\b)"};
}

int main()
{
    auto pat = "{}";
}
```

lizard reports **zero** functions (brace initialization), and with `=` initialization it reports `process@1-10`, swallowing `main`. Reported as #478.

## Why

This completes the raw-string handling started in #451. That change added a token pattern for `R"(...)"`, but its closing-delimiter character class `[^(\\]*` also matches a double quote. Since the token regex runs with `re.S` (DOTALL), that class raced past the real `)"` terminator and consumed everything up to the *next* `"`, across comments and newlines. The braces inside and after the literal then leaked into the nesting analysis, so the following function was merged in or dropped.

## Fix

Match the empty-delimiter form `R"(...)"` and stop at the first `)"`: a `)` only continues the body when it is not followed by a `"`. An optional encoding prefix (`u8` / `u` / `U` / `L`) is supported.

The pattern stays group-free to respect the tokenizer's `DO NOT put any sub groups` performance rule, so it does not use a backreference. Consequence, stated honestly: custom delimiters such as `R"json(...)json"` are not matched by the raw-string rule and fall through to the normal string-literal rule. That is correct for the common case (JSON/HTML bodies with balanced braces and no embedded `"`), and a regression test locks it. The one remaining gap is a custom-delimiter literal that contains *both* an embedded `"` and an unbalanced brace, which a backreference-free pattern cannot tie back to its opening delimiter.

The pattern is linear-time: the `[^)]` and `\)` branches are disjoint, so there is no catastrophic backtracking (a 50k-char literal tokenizes in ~24 ms here).

## Tests

Adds `Test_cpp_raw_string_literals` covering both initializer forms (with start/end line assertions, since the `=` variant was specifically a wrong line range), an encoding prefix, and the custom-delimiter fallthrough. The full suite is green; the inheriting languages (C#, Java, Objective-C, which share this tokenizer) were regression-checked. The pre-existing `testFilesFilter::test_gitignore_filter` failure is unrelated and also fails on a clean `master` in this environment.

Fixes #478.
