### PR TITLE
fix(objc): handle nested parens in block / function-pointer param types (#365)

### DIFF
--- a/lizard_languages/objc.py
+++ b/lizard_languages/objc.py
@@ -23,6 +23,10 @@ class ObjCReader(CLikeReader):
 
 
 class ObjCStates(CLikeStates):  # pylint: disable=R0903
+    def __init__(self, context):
+        super(ObjCStates, self).__init__(context)
+        self._objc_param_paren_depth = 0
+
     def _state_global(self, token):
         super(ObjCStates, self)._state_global(token)
         if token == 'typedef':
@@ -50,6 +54,7 @@ class ObjCStates(CLikeStates):  # pylint: disable=R0903
 
     def _state_objc_dec(self, token):
         if token == '(':
+            self._objc_param_paren_depth = 0
             self._state = self._state_objc_param_type
             self.context.add_to_long_function_name(token)
         elif token == ',':
@@ -61,8 +66,16 @@ class ObjCStates(CLikeStates):  # pylint: disable=R0903
             self.context.add_to_function_name(" " + token)
 
     def _state_objc_param_type(self, token):
-        if token == ')':
-            self._state = self._state_objc_param
+        # A block / function-pointer param type, e.g. (void (^)(int)), nests
+        # parentheses; balance them so the type ends at its matching ')'
+        # rather than the first inner one (issue #365).
+        if token == '(':
+            self._objc_param_paren_depth += 1
+        elif token == ')':
+            if self._objc_param_paren_depth > 0:
+                self._objc_param_paren_depth -= 1
+            else:
+                self._state = self._state_objc_param
         self.context.add_to_long_function_name(" " + token)
 
     def _state_objc_param(self, _):

--- a/test/test_languages/testObjC.py
+++ b/test/test_languages/testObjC.py
@@ -70,6 +70,41 @@ class Test_objc_lizard(unittest.TestCase):
         self.assertEqual(2, len(result))
         self.assertEqual("classMethod", result[0].name)
 
+    def test_objc_method_with_block_param(self):
+        # issue #365: a block-typed parameter "(void (^)(...))" contains
+        # nested parens; the param-type scan must balance them instead of
+        # exiting on the inner ')', which previously garbled the selector
+        # name and the method's line range.
+        code = (
+            "@implementation TestLizard\n"
+            "+ (UIImage *)sgb_imageWithSize:(CGSize)size "
+            "drawBlock:(void (^)(CGContextRef context))drawBlock {\n"
+            "    if (!drawBlock) return nil;\n"
+            "    return nil;\n"
+            "}\n"
+            "@end\n"
+        )
+        result = self.create_objc_lizard(code)
+        self.assertEqual(1, len(result))
+        self.assertEqual("sgb_imageWithSize: drawBlock:", result[0].name)
+        # the desync also corrupted the line range, so pin it too
+        self.assertEqual(2, result[0].start_line)
+        self.assertEqual(5, result[0].end_line)
+
+    def test_objc_method_with_function_pointer_param(self):
+        # same nested-paren path as #365: a function-pointer parameter type
+        # (int (*)(int)) must not end the param type at its inner ')'.
+        code = (
+            "@implementation TestLizard\n"
+            "- (void)runWithCallback:(int (*)(int))cb {\n"
+            "    return;\n"
+            "}\n"
+            "@end\n"
+        )
+        result = self.create_objc_lizard(code)
+        self.assertEqual(1, len(result))
+        self.assertEqual("runWithCallback:", result[0].name)
+
 
 class TestObjCLanguage(unittest.TestCase):
     """Tests for the GitHub issue #428 fix - .mm file extension mapping"""


### PR DESCRIPTION
## What

An Objective-C method whose selector takes a **block-typed parameter** is parsed with a garbled name and a wrong line range. Given:

```objc
@implementation TestLizard
+ (UIImage *)sgb_imageWithSize:(CGSize)size drawBlock:(void (^)(CGContextRef context))drawBlock {
    if (!drawBlock) return nil;
    return nil;
}
@end
```

lizard reports the function name as `sgb_imageWithSize: drawBlock: CGContextRef.nil` (the selector with tokens grafted in from the method body) over a collapsed `@10-11`-style range, instead of `sgb_imageWithSize: drawBlock:` over the real method body. Reported as #365.

## Why

`ObjCStates._state_objc_param_type` ends the parameter type at the **first** `)`. A block type `(void (^)(CGContextRef context))` (or a function-pointer type like `(int (*)(int))`) contains nested parentheses, so the scan exits at the inner `)` of `(^)`, desyncs the state machine, and never cleanly enters the method body. Both the selector name and the reported line range fall out of that one desync.

## Fix

Track parenthesis depth in `_state_objc_param_type` so the parameter type ends at its **matching** `)`. Plain parameter types like `(CGSize)size` have no nested parens, so the depth stays 0 and their handling is identical to before.

## Tests

- `test_objc_method_with_block_param` pins both the corrected selector name and the line range (both were corrupted).
- `test_objc_method_with_function_pointer_param` covers the same nested-paren path via a `(int (*)(int))` parameter.

The Objective-C suite passes and the existing plain-selector tests are unaffected.

Fixes #365.
