### PR TITLE
fix(script): stop a '#' comment continuing past a trailing backslash (#317)

### DIFF
--- a/lizard_languages/script_language.py
+++ b/lizard_languages/script_language.py
@@ -24,8 +24,11 @@ class ScriptLanguageMixIn:
 
     @staticmethod
     def generate_common_tokens(source_code, addition, match_holder=None):
-        _until_end = r"(?:\\\n|[^\n])*"
+        # A '#' line comment ends at the newline; a trailing backslash does
+        # not continue it onto the next line (issue #317). C/C++ '//' comments,
+        # which legitimately continue on a backslash, go through CodeReader
+        # directly and are unaffected.
         return CodeReader.generate_tokens(
             source_code,
-            r"|\#" + _until_end + addition,
+            r"|\#[^\n]*" + addition,
             match_holder)

--- a/test/test_languages/testRuby.py
+++ b/test/test_languages/testRuby.py
@@ -433,3 +433,23 @@ end
         self.assertEqual(2, len(result))
         self.assertEqual("adapt_widget_params", result[0].name)
         self.assertEqual("adapt_search_params", result[1].name)
+
+
+class Test_Ruby_comment_line_continuation(unittest.TestCase):
+    """A '#' comment ending in a backslash must not continue onto the next
+    line and swallow it (issue #317, the shared-tokenizer half)."""
+
+    def test_backslash_at_end_of_comment_keeps_next_line(self):
+        code = (
+            "def foo(x)\n"
+            "  # a trailing comment\\\n"
+            "  if x > 10\n"
+            "    return 1\n"
+            "  end\n"
+            "  return 0\n"
+            "end\n"
+        )
+        result = get_ruby_function_list(code)
+        self.assertEqual(1, len(result))
+        self.assertEqual("foo", result[0].name)
+        self.assertEqual(2, result[0].cyclomatic_complexity)


### PR DESCRIPTION
Completes the original #317. the f-string half (PR #481) plus your follow-up `a46756d` covered Python; this fixes the part you flagged as still separate - the backslash-in-comment continuation - for the languages that still go through the shared tokenizer.

## the bug

a `#` line comment whose last character is a backslash gets treated as a line continuation, so the comment swallows the next line. that's the original #317 repro:

```python
def testFunction(x):
    # this is a comment\
    if x > 10:
        return "..."
    return "..."
```

the `if` disappears into the comment, so CCN comes out 1 instead of 2. worse, a comment right before a function definition can hide the whole function from the report.

## the fix

`generate_common_tokens` built the `#` comment pattern from `_until_end = r"(?:\\\n|[^\n])*"`, which allows a backslash-newline continuation - the same idiom `code_reader` uses for C `//` comments, where continuation is real. none of the `#`-comment languages (ruby/perl/r) continue a comment on a backslash, so the pattern is now just `\#[^\n]*` (stops at the newline).

this is the same `\#[^\n]*` you already put in Python's `generate_tokens` in `a46756d`; here it's applied to the shared path Ruby/Perl/R still use. C/C++ `//` continuation lives in `code_reader` and is untouched.

## verified

- Ruby and Perl repros: CCN 1 to 2 (the `if` after the backslash comment is counted again)
- Python: unchanged (it routes around the shared path now)
- a Ruby regression test added; full suite green
- checked against real `ruby` and `perl`: a `#` comment ending in a backslash does not continue, matching interpreter behavior
