### PR TITLE
fix(java): count anonymous classes in field initializers (#311)

### DIFF
--- a/lizard_languages/java.py
+++ b/lizard_languages/java.py
@@ -61,6 +61,7 @@ class JavaStates(CLikeStates):  # pylint: disable=R0903
         self.handling_dot_class = False
         self.handling_method_ref = False
         self._java_after_unqualified_annotation = False
+        self._new_generic_depth = 0
 
     def _consume_java_expression_tokens(self, token):
         """Skip tokens that are not class declarations: Foo.class, Type::meth."""
@@ -186,6 +187,26 @@ class JavaStates(CLikeStates):  # pylint: disable=R0903
             self.in_record_constructor = False
             self._state = self._state_global
 
+    def _state_new(self, token):
+        self._new_generic_depth = 0
+        self.next(self._state_new_parameters)
+
+    def _state_new_parameters(self, token):
+        if self._new_generic_depth > 0 or token == "<":
+            # Skip the instantiated type's generic arguments, e.g. the <Long> in
+            # new ThreadLocal<Long>(), so they don't end the search for '(' / '{'.
+            self._new_generic_depth += token.count("<") - token.count(">")
+            return
+        if token == "(":
+            self.sub_state(JavaFunctionBodyStates(self.context, False), None, token)
+            return
+        if token == "{":
+            def callback():
+                self.next(self._state_global)
+            self.sub_state(JavaClassBodyStates("(anonymous)", False, self.context), callback, token)
+            return
+        self.next(self._state_global, token)
+
 
 class JavaFunctionBodyStates(JavaStates):
     def __init__(self, context, exit_with_brace_depth=True):
@@ -228,20 +249,6 @@ class JavaFunctionBodyStates(JavaStates):
     def _state_dummy(self, _):
         pass
 
-    def _state_new(self, token):
-        self.next(self._state_new_parameters)
-
-    def _state_new_parameters(self, token):
-        if token == "(":
-            self.sub_state(JavaFunctionBodyStates(self.context, False), None, token)
-            return
-        if token == "{":
-            def callback():
-                self.next(self._state_global)
-            self.sub_state(JavaClassBodyStates("(anonymous)", False, self.context), callback, token)
-            return
-        self.next(self._state_global, token)
-
 
 class JavaClassBodyStates(JavaStates):
     def __init__(self, class_name, is_record, context):
@@ -280,6 +287,13 @@ class JavaClassBodyStates(JavaStates):
             def _after_init_block():
                 self._class_body_brace -= 1
             self.sub_state(JavaFunctionBodyStates(self.context, True), _after_init_block, token)
+            return
+
+        if token == 'new':
+            # A field initializer may instantiate an anonymous class
+            # (= new Type<...>() { ... }); handle it so the field is not parsed as
+            # a method and the anonymous body's own methods are still counted.
+            self.next(self._state_new)
             return
 
         super()._state_global(token)

--- a/test/test_languages/testJava.py
+++ b/test/test_languages/testJava.py
@@ -31,6 +31,53 @@ public String funcB() {
         result = get_java_function_list("void fun() throws e1, e2{}")
         self.assertEqual(1, len(result))
 
+    def test_anonymous_class_in_field_initializer_issue_311(self):
+        code = """
+class T {
+    private ThreadLocal<Long> startTime = new ThreadLocal<Long>() {
+        @Override protected Long initialValue() { return 0L; }
+    };
+    void realMethod() { System.out.println("hi"); }
+}
+"""
+        result = get_java_function_list(code)
+        names = [f.name for f in result]
+        # the field declaration must not be picked up as a method
+        self.assertNotIn("T::ThreadLocal<Long>", names)
+        # the anonymous class's real method should be counted
+        self.assertIn("(anonymous)::initialValue", names)
+        self.assertIn("T::realMethod", names)
+
+    def test_generic_anonymous_class_in_method_body(self):
+        code = """
+class T {
+    void m() {
+        ThreadLocal<Long> x = new ThreadLocal<Long>() {
+            protected Long initialValue() { return 0L; }
+        };
+    }
+}
+"""
+        result = get_java_function_list(code)
+        names = [f.name for f in result]
+        self.assertIn("T::m", names)
+        self.assertIn("(anonymous)::initialValue", names)
+
+    def test_nested_generic_anonymous_class(self):
+        code = """
+class T {
+    private Map<String, List<Long>> m = new HashMap<String, List<Long>>() {
+        public int customSize() { if (isEmpty()) return 0; return 1; }
+    };
+    void realOuter() {}
+}
+"""
+        result = get_java_function_list(code)
+        names = [f.name for f in result]
+        self.assertEqual(2, len(result))
+        self.assertIn("(anonymous)::customSize", names)
+        self.assertIn("T::realOuter", names)
+
     def test_function_with_decorator(self):
         result = get_java_function_list("@abc() void fun() throws e1, e2{}")
         self.assertEqual(1, len(result))


### PR DESCRIPTION
Fixes #311.

## the problem

a field whose initializer is an anonymous class gets the field's type reported as a method, and the anonymous class's real methods are dropped:

```java
class T {
    private ThreadLocal<Long> startTime = new ThreadLocal<Long>() {
        @Override protected Long initialValue() { return 0L; }
    };
}
```

lizard reports a phantom `T::ThreadLocal<Long>` and never counts `initialValue`.

two things combine to cause it:

1. `JavaClassBodyStates` had no handling for `new`, so a field initializer fell through to the declaration parser, which read `ThreadLocal<Long>() { ... }` as a method.
2. even where `new` was handled (inside method bodies), the anonymous-class path bailed on the first `<`, so a generic type like `new ThreadLocal<Long>()` lost its body too. non-generic `new Runnable() { ... }` worked; the generic form did not.

## the fix

- hoist the `new` handling (`_state_new` / `_state_new_parameters`) up to the shared `JavaStates` base so both method bodies and class bodies use one copy.
- skip the instantiated type's generic arguments by bracket depth (`<…>`, counting `<`/`>` per token so split `>>` works) while searching for the constructor `(` or the anonymous body `{`.
- intercept `new` in `JavaClassBodyStates` so a field initializer's anonymous class is parsed as one, not as a method.

after this the example reports `(anonymous)::initialValue` and no phantom, and the same fix covers generic anonymous classes inside method bodies.

## scope

this handles unqualified types (`new ThreadLocal<...>()`). a qualified instantiation (`new java.util.X<...>() { ... }`) and a wildcard type argument (`new Cmp<? super T>() { ... }`) still misparse, but both already do that on master and are a separate pre-existing gap, so they're left for a follow-up.

## tests

three cases in `testJava.py`: the issue's field-initializer repro, a generic anonymous class in a method body, and a nested-generic (`Map<String, List<Long>>`) field initializer. all fail on master and pass with the fix; the full Java suite stays green.
