### PR TITLE
fix(golike): register generic functions with [...] type params

### DIFF
--- a/lizard_languages/golike.py
+++ b/lizard_languages/golike.py
@@ -57,11 +57,20 @@ class GoLikeStates(CodeStateMachine):  # pylint: disable=R0903
             self.next(self._function_dec, token)
         elif token == "<":
             self.next(self._generalize, token)
+        elif token == "[":
+            # Square-bracket type parameters, e.g. Scala `def f[T](x: T)` or
+            # Go `func F[T any](x T)`. Skip them like the `<>` generics above
+            # so the following `(` params still register the function.
+            self.next(self._generalize_type_params, token)
         else:
             self._state = self._state_global
 
     @CodeStateMachine.read_inside_brackets_then("<>", "_expect_function_dec")
     def _generalize(self, tokens):
+        pass
+
+    @CodeStateMachine.read_inside_brackets_then("[]", "_expect_function_dec")
+    def _generalize_type_params(self, tokens):
         pass
 
     @CodeStateMachine.read_inside_brackets_then("()", '_function_name')

--- a/test/test_languages/testGo.py
+++ b/test/test_languages/testGo.py
@@ -166,3 +166,17 @@ class Test_parser_for_Go(unittest.TestCase):
         self.assertEqual(1, len(result))
         self.assertEqual("getQuery", result[0].name)
         self.assertEqual(1, result[0].cyclomatic_complexity)
+
+    def test_generic_function_with_type_param(self):
+        result = get_go_function_list('''
+            func Map[T any](x T) T { return x }
+                ''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("Map", result[0].name)
+
+    def test_generic_function_with_multiple_type_params(self):
+        result = get_go_function_list('''
+            func Reduce[T any, U any](xs []T, acc U) U { return acc }
+                ''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("Reduce", result[0].name)

--- a/test/test_languages/testScala.py
+++ b/test/test_languages/testScala.py
@@ -128,3 +128,30 @@ class TestScala(unittest.TestCase):
             ''')
         self.assertEqual(2, len(result))
         self.assertEqual('list2', result[0].name)
+
+    def test_generic_function_with_type_param(self):
+        result = get_scala_function_list('''
+            def identity[T](x: T): T = { x }
+                ''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("identity", result[0].name)
+        self.assertEqual(1, result[0].parameter_count)
+
+    def test_generic_function_with_multiple_type_params(self):
+        result = get_scala_function_list('''
+            def merge[A, B](a: A, b: B): String = { a.toString + b.toString }
+                ''')
+        self.assertEqual(1, len(result))
+        self.assertEqual("merge", result[0].name)
+        self.assertEqual(2, result[0].parameter_count)
+
+    def test_generic_method_in_class_not_dropped(self):
+        result = get_scala_function_list('''
+            class Box {
+                def plain(x: Int): Int = { x + 1 }
+                def generic[T](x: T): T = { x }
+                def after(y: Int): Int = { y * 2 }
+            }
+                ''')
+        names = sorted(f.name for f in result)
+        self.assertEqual(["after", "generic", "plain"], names)


### PR DESCRIPTION
## what

generic functions/methods with a square-bracket type-param list were dropped or mis-parsed (no name, wrong param count). this registers them correctly.

```scala
def identity[T](x: T): T = { x }   // before: not counted at all
```
```go
func Map[T any](x T) T { return x }   // same
```

## why

in `golike.py`, after a function name `_expect_function_dec` only handled `(` (value params) and `<` (the `<>` generics). a `[` - Scala `def f[T](...)` or Go 1.18 `func F[T any](...)` - fell through to the `else` and bailed back to `_state_global`, so the function was never registered. this affects every golike-based reader: go, scala, kotlin, rust, swift, zig, solidity.

## fix

one branch in `_expect_function_dec` that skips the `[...]` list via `_generalize_type_params`, mirroring the existing `<>` `_generalize`. once the type params are skipped, the following `(` params register the function as normal.

## tests

- `testScala.py`: generic method with one type param, with multiple type params, and a generic method inside a class body (the drop-in-context case)
- `testGo.py`: `[T any]` and multiple type params `[T any, U any]`

## known limitation

this covers the common `def f[T](...)` / `func F[T any](...)` shape. paren-less generic defs like Scala `def empty[T]: List[T]` are still dropped, same as the existing paren-less-def limitation - out of scope here, since closing it means changing how paren-less defs register in general.
