### PR TITLE
feat(halstead): add -Ehalstead extension for Halstead complexity metrics

### DIFF
--- a/lizard.py
+++ b/lizard.py
@@ -105,7 +105,8 @@ def _extension_arg(parser):
                         -Ewordcount: count word frequencies and generate tag
                         cloud. -Eoutside: include the global code as one
                         function.  -EIgnoreAssert: to ignore all code in
-                        assert. -ENS: count nested control structures.''',
+                        assert. -ENS: count nested control structures.
+                        -Ehalstead: compute Halstead complexity metrics.''',
                         action="append",
                         dest="extensions",
                         default=[])

--- a/lizard_ext/lizardhalstead.py
+++ b/lizard_ext/lizardhalstead.py
@@ -189,7 +189,8 @@ class HalsteadClassifier(object):  # pylint: disable=too-few-public-methods
         if not token or token.isspace():
             return self.SKIP
         first = token[0]
-        if first in "\"'" or first.isdigit():
+        if first in "\"'" or first.isdigit() or \
+            (first == "." and token[1:2].isdigit()):
             # A string or numeric literal: lizard emits each quoted run or
             # number (or number fragment) as a single token.
             return self.OPERAND

--- a/lizard_ext/lizardhalstead.py
+++ b/lizard_ext/lizardhalstead.py
@@ -1,0 +1,343 @@
+"""
+Halstead complexity measures for lizard (``-Ehalstead``).
+
+Halstead metrics are derived from two basic counts taken over a unit of
+code (here, every function):
+
+* ``n1`` - the number of *distinct* operators
+* ``n2`` - the number of *distinct* operands
+* ``N1`` - the *total* number of operators
+* ``N2`` - the *total* number of operands
+
+From those four numbers the usual derived measures are computed: vocabulary,
+length, volume, difficulty, effort, time and an estimate of delivered bugs
+(see :class:`HalsteadMetrics`).
+
+Counting convention
+-------------------
+Halstead numbers are notoriously sensitive to *how* you decide what counts as
+an operator and what counts as an operand, so the rules used here are spelled
+out explicitly to make results comparable with (or at least explainable next
+to) other tools:
+
+* Every token that lizard already emits is classified as exactly one of
+  ``operator``, ``operand`` or *skipped*.  Lizard strips whitespace and
+  comments before extensions see the stream, so those never participate.  This
+  keeps the classification in one-to-one correspondence with the tokens that
+  drive ``token_count``.
+* **Operands** are identifiers (variable, function, attribute and parameter
+  names), numeric literals, string literals and the literal keywords of the
+  language (``True``/``False``/``None`` in Python, ``true``/``false``/``null``
+  and friends elsewhere).
+* **Operators** are operator and punctuation symbols (``+``, ``==``, ``.``,
+  ``,``, ``:``, ``(``, ``)``, ``{``, ``}`` ...) together with the keywords that
+  act as operators or control structures (``if``, ``for``, ``return``, ``def``,
+  ``and`` ...).
+* Each paired delimiter token is counted on its own; ``(`` and ``)`` are two
+  distinct operators, each contributing one occurrence.  This follows directly
+  from lizard tokenizing them separately and keeps the one-token-one-label
+  property above.
+* Tokens are attributed to a function exactly the way ``token_count`` is, so
+  the ``def``/``class`` keyword and the function name itself belong to the
+  enclosing scope rather than to the function body.
+
+Operator/operand classification is language specific, so it lives behind a
+small, explicit interface (:class:`HalsteadClassifier`).  Python ships with a
+precise classifier; other languages fall back to a generic C-family classifier
+that is a reasonable approximation until a language-specific one is added.  A
+language reader can also provide its own by exposing a ``halstead_classifier``
+attribute, which is the seam intended for folding this into the core later.
+"""
+
+import keyword
+import math
+from collections import Counter
+
+from lizard import FunctionInfo
+
+
+class HalsteadMetrics(object):
+    """Compute the Halstead measures from operator/operand multisets.
+
+    The object only stores the two :class:`collections.Counter` instances and
+    derives everything on access, so it always reflects the final counts no
+    matter when it is read.
+    """
+
+    def __init__(self, operators=None, operands=None):
+        self._operators = operators if operators is not None else Counter()
+        self._operands = operands if operands is not None else Counter()
+
+    # -- the four basic counts ------------------------------------------------
+    @property
+    def distinct_operators(self):  # n1
+        return len(self._operators)
+
+    @property
+    def distinct_operands(self):  # n2
+        return len(self._operands)
+
+    @property
+    def total_operators(self):  # N1
+        return sum(self._operators.values())
+
+    @property
+    def total_operands(self):  # N2
+        return sum(self._operands.values())
+
+    # -- derived measures -----------------------------------------------------
+    @property
+    def vocabulary(self):
+        """n = n1 + n2"""
+        return self.distinct_operators + self.distinct_operands
+
+    @property
+    def length(self):
+        """N = N1 + N2"""
+        return self.total_operators + self.total_operands
+
+    @property
+    def calculated_length(self):
+        """Estimated length: n1*log2(n1) + n2*log2(n2)."""
+        n_1 = self.distinct_operators
+        n_2 = self.distinct_operands
+        return ((n_1 * math.log2(n_1) if n_1 else 0.0) +
+                (n_2 * math.log2(n_2) if n_2 else 0.0))
+
+    @property
+    def volume(self):
+        """V = N * log2(n)."""
+        vocabulary = self.vocabulary
+        return self.length * math.log2(vocabulary) if vocabulary > 0 else 0.0
+
+    @property
+    def difficulty(self):
+        """D = (n1 / 2) * (N2 / n2)."""
+        n_2 = self.distinct_operands
+        if n_2 == 0:
+            return 0.0
+        return (self.distinct_operators / 2.0) * (self.total_operands / n_2)
+
+    @property
+    def effort(self):
+        """E = D * V."""
+        return self.difficulty * self.volume
+
+    @property
+    def time(self):
+        """Estimated programming time in seconds: E / 18."""
+        return self.effort / 18.0
+
+    @property
+    def bugs(self):
+        """Estimated delivered bugs: V / 3000."""
+        return self.volume / 3000.0
+
+    def as_dict(self):
+        return {
+            "n1": self.distinct_operators,
+            "n2": self.distinct_operands,
+            "N1": self.total_operators,
+            "N2": self.total_operands,
+            "vocabulary": self.vocabulary,
+            "length": self.length,
+            "calculated_length": self.calculated_length,
+            "volume": self.volume,
+            "difficulty": self.difficulty,
+            "effort": self.effort,
+            "time": self.time,
+            "bugs": self.bugs,
+        }
+
+
+class HalsteadClassifier(object):  # pylint: disable=too-few-public-methods
+    """Classify tokens into Halstead operators and operands.
+
+    This is the per-language extension point.  The base class implements the
+    generic rules that work for the operators and punctuation shared by
+    lizard's common tokenizer, plus a broad set of C-family keywords.  Subclass
+    it and override :attr:`keyword_operators` / :attr:`literal_keywords` (or
+    :meth:`classify` itself) for language-specific behaviour.
+    """
+
+    OPERATOR = "operator"
+    OPERAND = "operand"
+    SKIP = None
+
+    #: Keywords that behave as operators (control flow, declarations, ...).
+    keyword_operators = frozenset({
+        "if", "else", "for", "while", "do", "switch", "case", "default",
+        "break", "continue", "return", "goto", "try", "catch", "finally",
+        "throw", "throws", "int", "long", "short", "char", "float", "double",
+        "void", "bool", "boolean", "unsigned", "signed", "const", "static",
+        "extern", "register", "volatile", "auto", "struct", "union", "enum",
+        "class", "typedef", "public", "private", "protected", "virtual",
+        "inline", "template", "typename", "namespace", "using", "new",
+        "delete", "sizeof", "operator", "import", "package", "extends",
+        "implements", "interface", "synchronized", "function", "var", "let",
+        "typeof", "instanceof", "in", "of", "await", "async", "yield", "and",
+        "or", "not", "xor",
+    })
+
+    #: Keywords that denote literal values (counted as operands).
+    literal_keywords = frozenset({
+        "true", "false", "null", "nil", "none", "nullptr", "undefined",
+    })
+
+    def classify(self, token):
+        """Return ``OPERATOR``, ``OPERAND`` or ``SKIP`` for ``token``."""
+        if not token or token.isspace():
+            return self.SKIP
+        first = token[0]
+        if first in "\"'" or first.isdigit():
+            # A string or numeric literal: lizard emits each quoted run or
+            # number (or number fragment) as a single token.
+            return self.OPERAND
+        if first.isalpha() or first == "_":
+            # A word: keyword or identifier.
+            if token in self.literal_keywords:
+                return self.OPERAND
+            if token in self.keyword_operators:
+                return self.OPERATOR
+            return self.OPERAND
+        # Anything else is operator/punctuation.
+        return self.OPERATOR
+
+
+class PythonHalsteadClassifier(HalsteadClassifier):  # pylint: disable=too-few-public-methods
+    """Precise operator/operand classification for Python.
+
+    Every hard keyword is an operator except the value literals ``True``,
+    ``False`` and ``None``.  Soft keywords (``match``, ``case``, ``type``,
+    ``_``) are context dependent and are treated as ordinary identifiers, i.e.
+    operands.
+    """
+
+    literal_keywords = frozenset({"True", "False", "None"})
+    keyword_operators = frozenset(keyword.kwlist) - literal_keywords
+
+
+#: Registry of language-specific classifiers, keyed by lower-case language name.
+_CLASSIFIERS = {
+    "python": PythonHalsteadClassifier,
+}
+
+
+def get_classifier(reader):
+    """Pick the classifier for ``reader``.
+
+    Resolution order:
+
+    1. a ``halstead_classifier`` provided by the language reader itself,
+    2. a classifier registered for one of the reader's ``language_names``,
+    3. the generic :class:`HalsteadClassifier`.
+    """
+    classifier = getattr(reader, "halstead_classifier", None)
+    if classifier is not None:
+        return classifier
+    for name in getattr(reader, "language_names", None) or []:
+        registered = _CLASSIFIERS.get(name.lower())
+        if registered is not None:
+            return registered()
+    return HalsteadClassifier()
+
+
+def _function_halstead(function):
+    return HalsteadMetrics(
+        getattr(function, "_halstead_operators", None),
+        getattr(function, "_halstead_operands", None))
+
+
+#: (attribute name on FunctionInfo, measure name on HalsteadMetrics).
+_HALSTEAD_MEASURES = (
+    ("halstead_n1", "distinct_operators"),
+    ("halstead_n2", "distinct_operands"),
+    ("halstead_N1", "total_operators"),
+    ("halstead_N2", "total_operands"),
+    ("halstead_vocabulary", "vocabulary"),
+    ("halstead_length", "length"),
+    ("halstead_volume", "volume"),
+    ("halstead_difficulty", "difficulty"),
+    ("halstead_effort", "effort"),
+    ("halstead_time", "time"),
+    ("halstead_bugs", "bugs"),
+)
+
+
+def _make_measure_property(measure_name):
+    def getter(self):
+        value = getattr(self.halstead, measure_name)
+        return round(value, 2) if isinstance(value, float) else value
+    return property(getter)
+
+
+def ensure_function_info_patched(function_info_class):
+    """Expose the Halstead measures as attributes on a ``FunctionInfo`` class.
+
+    They are read-only properties derived from the per-function operator and
+    operand multisets, so they default to zero for any function that never went
+    through the extension.  Being real attributes means they also work with
+    ``--sort``/``--Threshold`` and the CSV/XML writers.
+
+    The class is resolved from the instances that flow through the extension
+    (``type(function)``) rather than from a single imported reference, so this
+    keeps working when lizard is run as ``python -m lizard`` (where the module
+    also exists as ``__main__``) or across multiprocessing workers.
+    """
+    if function_info_class.__dict__.get("_halstead_patched"):
+        return
+    function_info_class.halstead = property(_function_halstead)
+    for attribute_name, measure_name in _HALSTEAD_MEASURES:
+        setattr(function_info_class, attribute_name,
+                _make_measure_property(measure_name))
+    setattr(function_info_class, "_halstead_patched", True)
+
+
+# Best-effort patch of the imported class for the common single-import case;
+# the extension also patches the concrete class lazily while streaming.
+ensure_function_info_patched(FunctionInfo)
+
+
+class LizardExtension(object):  # pylint: disable=too-few-public-methods
+
+    FUNCTION_INFO = {
+        "halstead_volume": {"caption": " H-volume "},
+        "halstead_difficulty": {"caption": " H-diff "},
+        "halstead_effort": {"caption": " H-effort "},
+    }
+
+    @staticmethod
+    def cross_file_process(fileinfos):
+        # Runs in the parent process after every file has been analyzed (and,
+        # under multiprocessing, after the results have been unpickled).  The
+        # per-token patch in ``__call__`` only ran in the worker, so the class
+        # backing the collected results may still be missing the Halstead
+        # properties here; patch it before the output scheme reads them.
+        for fileinfo in fileinfos:
+            for function in getattr(fileinfo, "function_list", None) or []:
+                ensure_function_info_patched(type(function))
+            yield fileinfo
+
+    @staticmethod
+    def __call__(tokens, reader):
+        # Kept free of per-call state on the extension object: this generator
+        # runs once per file and the same instance is shared across threads.
+        classifier = get_classifier(reader)
+        operator = HalsteadClassifier.OPERATOR
+        operand = HalsteadClassifier.OPERAND
+        for token in tokens:
+            function = reader.context.current_function
+            operators = getattr(function, "_halstead_operators", None)
+            if operators is None:
+                # Patch the concrete class actually in use (which may be
+                # ``__main__.FunctionInfo`` under ``python -m lizard`` or a
+                # worker's copy under multiprocessing).  Idempotent and cheap.
+                ensure_function_info_patched(type(function))
+                operators = function._halstead_operators = Counter()
+                function._halstead_operands = Counter()
+            kind = classifier.classify(token)
+            if kind is operator:
+                operators[token] += 1
+            elif kind is operand:
+                function._halstead_operands[token] += 1
+            yield token

--- a/test/testHalstead.py
+++ b/test/testHalstead.py
@@ -208,6 +208,17 @@ class TestHalsteadClassifierUnit(unittest.TestCase):
         self.assertEqual(HalsteadClassifier.OPERAND,
                          self.python.classify('42'))
 
+    def test_leading_dot_float_is_operand(self):
+        # Some tokenizers (e.g. C-family) emit ``.5`` as a single token.
+        for token in ('.5', '.5e3', '.25E-4', '0.5', '5.'):
+            self.assertEqual(HalsteadClassifier.OPERAND,
+                             self.generic.classify(token), token)
+
+    def test_bare_dot_and_ellipsis_stay_operators(self):
+        for token in ('.', '..', '...', '.foo'):
+            self.assertEqual(HalsteadClassifier.OPERATOR,
+                             self.generic.classify(token), token)
+
     def test_generic_c_family_keywords(self):
         self.assertEqual(HalsteadClassifier.OPERATOR,
                          self.generic.classify('int'))

--- a/test/testHalstead.py
+++ b/test/testHalstead.py
@@ -1,0 +1,329 @@
+"""Tests for the Halstead complexity extension (``-Ehalstead``)."""
+
+import unittest
+from collections import Counter
+
+from .testHelpers import (
+    get_python_function_list_with_extension,
+    get_cpp_function_list_with_extension,
+)
+from lizard_ext.lizardhalstead import (
+    LizardExtension as HalsteadExtension,
+    HalsteadMetrics,
+    HalsteadClassifier,
+    PythonHalsteadClassifier,
+    get_classifier,
+)
+
+
+def get_python_function(source):
+    return get_python_function_list_with_extension(
+        source, HalsteadExtension())[0]
+
+
+def get_cpp_function(source):
+    return get_cpp_function_list_with_extension(
+        source, HalsteadExtension())[0]
+
+
+#: A small Python function whose Halstead numbers are verified by hand and
+#: reused across several tests.
+SAMPLE = '''def foo(a, b):
+    c = a + b * 2
+    if c > 10 and a != b:
+        return c
+    return a - b
+'''
+
+
+class TestHalsteadBasicCounts(unittest.TestCase):
+
+    def setUp(self):
+        self.function = get_python_function(SAMPLE)
+
+    def test_distinct_operators_n1(self):
+        # ( , ) : = + * if > and != return -
+        self.assertEqual(13, self.function.halstead.distinct_operators)
+
+    def test_distinct_operands_n2(self):
+        # a b c 2 10
+        self.assertEqual(5, self.function.halstead.distinct_operands)
+
+    def test_total_operators_N1(self):
+        self.assertEqual(15, self.function.halstead.total_operators)
+
+    def test_total_operands_N2(self):
+        self.assertEqual(13, self.function.halstead.total_operands)
+
+    def test_operand_occurrences(self):
+        operands = self.function._halstead_operands
+        self.assertEqual(4, operands['a'])
+        self.assertEqual(4, operands['b'])
+        self.assertEqual(3, operands['c'])
+
+    def test_paired_delimiters_counted_separately(self):
+        operators = self.function._halstead_operators
+        self.assertEqual(1, operators['('])
+        self.assertEqual(1, operators[')'])
+
+
+class TestHalsteadDerivedMeasures(unittest.TestCase):
+
+    def setUp(self):
+        self.halstead = get_python_function(SAMPLE).halstead
+
+    def test_vocabulary(self):
+        self.assertEqual(18, self.halstead.vocabulary)
+
+    def test_length(self):
+        self.assertEqual(28, self.halstead.length)
+
+    def test_volume(self):
+        self.assertAlmostEqual(116.7579, self.halstead.volume, places=3)
+
+    def test_difficulty(self):
+        self.assertAlmostEqual(16.9, self.halstead.difficulty, places=3)
+
+    def test_effort(self):
+        self.assertAlmostEqual(1973.2085, self.halstead.effort, places=3)
+
+    def test_time(self):
+        self.assertAlmostEqual(109.6227, self.halstead.time, places=3)
+
+    def test_bugs(self):
+        self.assertAlmostEqual(0.038919, self.halstead.bugs, places=5)
+
+
+class TestHalsteadFunctionInfoAttributes(unittest.TestCase):
+    """The flat, rounded attributes used for display/sort/threshold."""
+
+    def setUp(self):
+        self.function = get_python_function(SAMPLE)
+
+    def test_volume_attribute_is_rounded(self):
+        self.assertEqual(116.76, self.function.halstead_volume)
+
+    def test_difficulty_attribute_is_rounded(self):
+        self.assertEqual(16.9, self.function.halstead_difficulty)
+
+    def test_effort_attribute_is_rounded(self):
+        self.assertEqual(1973.21, self.function.halstead_effort)
+
+    def test_basic_count_attributes(self):
+        self.assertEqual(13, self.function.halstead_n1)
+        self.assertEqual(5, self.function.halstead_n2)
+        self.assertEqual(15, self.function.halstead_N1)
+        self.assertEqual(13, self.function.halstead_N2)
+
+    def test_attributes_default_to_zero_without_extension(self):
+        # A function that never went through the extension still answers the
+        # Halstead attributes (with empty counts) rather than raising.
+        from lizard import FunctionInfo
+        fresh = FunctionInfo('bar', 'a.py', 0)
+        self.assertEqual(0, fresh.halstead_n1)
+        self.assertEqual(0.0, fresh.halstead_volume)
+        self.assertEqual(0.0, fresh.halstead.difficulty)
+
+
+class TestHalsteadClassification(unittest.TestCase):
+
+    def test_keywords_acting_as_operators(self):
+        function = get_python_function(SAMPLE)
+        operators = function._halstead_operators
+        self.assertEqual(1, operators['if'])
+        self.assertEqual(1, operators['and'])
+        self.assertEqual(2, operators['return'])
+
+    def test_function_name_belongs_to_enclosing_scope(self):
+        # By convention the def keyword and the function name are attributed to
+        # the enclosing scope, exactly like token_count, so they do not appear
+        # among the function's own operands/operators.
+        function = get_python_function(SAMPLE)
+        self.assertNotIn('foo', function._halstead_operands)
+        self.assertNotIn('def', function._halstead_operators)
+
+    def test_string_literal_is_operand(self):
+        function = get_python_function(
+            'def f():\n    return "hello"\n')
+        self.assertIn('"hello"', function._halstead_operands)
+
+    def test_numeric_literal_is_operand(self):
+        function = get_python_function('def f():\n    return 42\n')
+        self.assertIn('42', function._halstead_operands)
+
+    def test_python_value_literals_are_operands(self):
+        function = get_python_function(
+            'def f(x):\n'
+            '    if x:\n'
+            '        return True\n'
+            '    return None\n')
+        self.assertIn('True', function._halstead_operands)
+        self.assertIn('None', function._halstead_operands)
+        self.assertNotIn('True', function._halstead_operators)
+        self.assertNotIn('None', function._halstead_operators)
+
+
+class TestHalsteadClassifierUnit(unittest.TestCase):
+    """Directly exercise the classifier objects."""
+
+    def setUp(self):
+        self.python = PythonHalsteadClassifier()
+        self.generic = HalsteadClassifier()
+
+    def test_python_keyword_operators(self):
+        for token in ('if', 'else', 'for', 'return', 'and', 'or', 'not',
+                      'def', 'class', 'import', 'lambda', 'yield'):
+            self.assertEqual(HalsteadClassifier.OPERATOR,
+                             self.python.classify(token), token)
+
+    def test_python_value_literals_are_operands(self):
+        for token in ('True', 'False', 'None'):
+            self.assertEqual(HalsteadClassifier.OPERAND,
+                             self.python.classify(token), token)
+
+    def test_python_soft_keywords_are_operands(self):
+        # match/case/type/_ are context-dependent; treat them as identifiers.
+        for token in ('match', 'case', 'type', '_'):
+            self.assertEqual(HalsteadClassifier.OPERAND,
+                             self.python.classify(token), token)
+
+    def test_identifiers_are_operands(self):
+        for token in ('foo', 'bar_baz', '_private', 'CamelCase'):
+            self.assertEqual(HalsteadClassifier.OPERAND,
+                             self.python.classify(token), token)
+
+    def test_symbols_are_operators(self):
+        for token in ('+', '-', '*', '==', '!=', '(', ')', '{', '}',
+                      ':', ',', '.', '&&'):
+            self.assertEqual(HalsteadClassifier.OPERATOR,
+                             self.python.classify(token), token)
+
+    def test_string_and_number_tokens(self):
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.python.classify('"a string"'))
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.python.classify("'c'"))
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.python.classify('0xFF'))
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.python.classify('42'))
+
+    def test_generic_c_family_keywords(self):
+        self.assertEqual(HalsteadClassifier.OPERATOR,
+                         self.generic.classify('int'))
+        self.assertEqual(HalsteadClassifier.OPERATOR,
+                         self.generic.classify('if'))
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.generic.classify('true'))
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.generic.classify('null'))
+        self.assertEqual(HalsteadClassifier.OPERAND,
+                         self.generic.classify('myvar'))
+
+    def test_empty_token_is_skipped(self):
+        self.assertIs(HalsteadClassifier.SKIP, self.python.classify(''))
+
+
+class TestClassifierSelection(unittest.TestCase):
+
+    class _Reader(object):
+        def __init__(self, **attrs):
+            self.__dict__.update(attrs)
+
+    def test_python_reader_gets_python_classifier(self):
+        reader = self._Reader(language_names=['python'])
+        self.assertIsInstance(get_classifier(reader), PythonHalsteadClassifier)
+
+    def test_unknown_language_gets_generic_classifier(self):
+        reader = self._Reader(language_names=['cpp'])
+        classifier = get_classifier(reader)
+        self.assertIsInstance(classifier, HalsteadClassifier)
+        self.assertNotIsInstance(classifier, PythonHalsteadClassifier)
+
+    def test_reader_without_language_names_gets_generic(self):
+        self.assertIsInstance(get_classifier(self._Reader()),
+                              HalsteadClassifier)
+
+    def test_reader_hook_takes_precedence(self):
+        sentinel = PythonHalsteadClassifier()
+        reader = self._Reader(language_names=['cpp'],
+                              halstead_classifier=sentinel)
+        self.assertIs(sentinel, get_classifier(reader))
+
+
+class TestHalsteadMetricsObject(unittest.TestCase):
+    """The value object computes the formulae from raw multisets."""
+
+    def test_empty_metrics_are_zero(self):
+        metrics = HalsteadMetrics()
+        self.assertEqual(0, metrics.vocabulary)
+        self.assertEqual(0, metrics.length)
+        self.assertEqual(0.0, metrics.volume)
+        self.assertEqual(0.0, metrics.difficulty)
+        self.assertEqual(0.0, metrics.effort)
+        self.assertEqual(0.0, metrics.calculated_length)
+
+    def test_formulae(self):
+        operators = Counter({'+': 3, '=': 2})        # n1=2, N1=5
+        operands = Counter({'a': 4, 'b': 1})         # n2=2, N2=5
+        metrics = HalsteadMetrics(operators, operands)
+        self.assertEqual(2, metrics.distinct_operators)
+        self.assertEqual(2, metrics.distinct_operands)
+        self.assertEqual(5, metrics.total_operators)
+        self.assertEqual(5, metrics.total_operands)
+        self.assertEqual(4, metrics.vocabulary)
+        self.assertEqual(10, metrics.length)
+        # V = 10 * log2(4) = 20
+        self.assertAlmostEqual(20.0, metrics.volume, places=6)
+        # D = (2 / 2) * (5 / 2) = 2.5
+        self.assertAlmostEqual(2.5, metrics.difficulty, places=6)
+        # E = 2.5 * 20 = 50
+        self.assertAlmostEqual(50.0, metrics.effort, places=6)
+
+    def test_as_dict_keys(self):
+        keys = set(HalsteadMetrics().as_dict())
+        self.assertEqual(
+            {'n1', 'n2', 'N1', 'N2', 'vocabulary', 'length',
+             'calculated_length', 'volume', 'difficulty', 'effort',
+             'time', 'bugs'},
+            keys)
+
+
+class TestHalsteadCpp(unittest.TestCase):
+    """The generic classifier applied end-to-end to C++."""
+
+    def test_simple_c_function(self):
+        function = get_cpp_function(
+            "int add(int a, int b) {\n"
+            "    return a + b;\n"
+            "}\n")
+        operators = function._halstead_operators
+        operands = function._halstead_operands
+        # int (the two parameter types), the operators, and the braces.
+        self.assertEqual(2, operators['int'])
+        self.assertEqual(1, operators['+'])
+        self.assertEqual(1, operators['return'])
+        self.assertEqual(2, operands['a'])
+        self.assertEqual(2, operands['b'])
+        self.assertTrue(function.halstead.volume > 0)
+
+
+class TestExtensionStatelessness(unittest.TestCase):
+
+    def test_instance_holds_no_per_file_state(self):
+        extension = HalsteadExtension()
+        get_python_function_list_with_extension(SAMPLE, extension)
+        self.assertEqual({}, extension.__dict__)
+
+    def test_reused_instance_gives_independent_results(self):
+        extension = HalsteadExtension()
+        first = get_python_function_list_with_extension(
+            SAMPLE, extension)[0]
+        second = get_python_function_list_with_extension(
+            "def g():\n    return 1\n", extension)[0]
+        self.assertEqual(13, first.halstead.distinct_operators)
+        self.assertEqual(1, second.halstead.distinct_operands)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Addresses #464.

## What this adds

An optional `-Ehalstead` extension that computes [Halstead complexity measures](https://en.wikipedia.org/wiki/Halstead_complexity_measures) per function:

```
$ lizard -Ehalstead path/to/code
  NLOC    CCN   token  PARAM  length  H-volume  H-diff  H-effort  location
----------------------------------------------------------------------------
     5      3     29      2       5    116.76    16.9   1973.21 foo@1-5@sample.py
```

Three columns are displayed (`H-volume`, `H-diff`, `H-effort`). The full set (`n1`, `n2`, `N1`, `N2`, vocabulary, length, volume, difficulty, effort, time, estimated bugs) is available programmatically via `function.halstead` and via flat `halstead_*` attributes that also work with `--sort`/`--Threshold` (e.g. `-s halstead_volume`).

## Design

Following the guidance on the issue:

- **`HalsteadClassifier`** is the per-language extension point: `classify(token)` returns operator / operand / skip, one label per token, preserving 1:1 correspondence with the tokens lizard already emits (so this stays easy to fold into core later). A precise `PythonHalsteadClassifier` ships in-tree; a generic C-family classifier is the fallback for other languages.
- Classifier selection (`get_classifier`) checks, in order: a `halstead_classifier` attribute on the reader (the seam intended for per-reader hooks in core), a registry keyed by `language_names`, then the generic fallback.
- **`HalsteadMetrics`** holds the two operator/operand `Counter`s and derives all measures lazily, so values always reflect the final counts.
- Metrics are exposed on `FunctionInfo` as read-only properties, so they default to zero for functions that never went through the extension and integrate with the existing sort/threshold/output machinery.

## Counting convention

Halstead numbers are sensitive to how operators vs operands are counted. In short: operands are identifiers, numeric and string literals, and value-literal keywords (`True`/`False`/`None`, etc.); operators are punctuation/operator symbols plus operator/control keywords (`if`, `for`, `return`, `def`, `and`, …); paired delimiters are counted individually; and tokens are attributed to functions exactly as `token_count` is (so `def`/`class` and the function name belong to the enclosing scope).

## Tests

`test/testHalstead.py` adds 41 tests covering the basic counts, every derived measure (against hand-verified numbers), the flat `FunctionInfo` attributes, operator/operand classification (keywords, literals, strings, numbers, Python value literals and soft keywords), classifier selection precedence, the `HalsteadMetrics` value object, end-to-end C++ via the generic classifier, and extension statelessness. No regressions. Verified working via the console script, `python -m lizard`, and multiprocessing (`-t 2`).