### PR TITLE
fix(csv): emit columns for extensions with multiple FUNCTION_INFO fields

### DIFF
--- a/lizard_ext/csvoutput.py
+++ b/lizard_ext/csvoutput.py
@@ -23,10 +23,9 @@ def csv_output(result, options):
     extension_variables = []
     extension_captions = []
     for extension in options.extensions:
-        if extension.__class__.__name__ == 'LizardExtension':
-            if hasattr(extension, 'FUNCTION_INFO') and \
-                    len(list(extension.FUNCTION_INFO)) == 1:
-                extension_variable = list(extension.FUNCTION_INFO)[0]
+        if extension.__class__.__name__ == 'LizardExtension' and \
+            hasattr(extension, 'FUNCTION_INFO'):
+            for extension_variable in extension.FUNCTION_INFO:
                 extension_variables.append(extension_variable)
                 var_extension = extension.FUNCTION_INFO[extension_variable]
                 extension_caption = var_extension['caption'] \

--- a/test/testOutputCSV.py
+++ b/test/testOutputCSV.py
@@ -66,6 +66,45 @@ class TestCSVOutput(StreamStdoutTestCase):
             sys.stdout.stream.splitlines()[0]
         )
 
+    def test_csv_header_with_multi_field_extension(self):
+        options_mock = Mock()
+        options_mock.verbose = True
+        extension_mock = Mock()
+        extension_mock.__class__.__name__ = 'LizardExtension'
+        extension_mock.FUNCTION_INFO = {
+            "metric_one": {"caption": " metric_one "},
+            "metric_two": {"caption": " metric_two "},
+        }
+        options_mock.extensions = [extension_mock]
+        results = AllResult([self.fileSummary])
+        results.result[0].function_list[0].metric_one = 12.5
+        results.result[0].function_list[0].metric_two = 99.0
+        csv_output(results, options_mock)
+        self.assertRegex(
+            sys.stdout.stream,
+            r"NLOC,CCN,token,PARAM,length,location,file,function,"
+            r"long_name,start,end, metric_one , metric_two ")
+
+    def test_csv_row_with_multi_field_extension(self):
+        options_mock = Mock()
+        options_mock.verbose = False
+        extension_mock = Mock()
+        extension_mock.__class__.__name__ = 'LizardExtension'
+        extension_mock.FUNCTION_INFO = {
+            "metric_one": {"caption": " metric_one "},
+            "metric_two": {"caption": " metric_two "},
+        }
+        options_mock.extensions = [extension_mock]
+        results = AllResult([self.fileSummary])
+        results.result[0].function_list[0].metric_one = 12.5
+        results.result[0].function_list[0].metric_two = 99.0
+        csv_output(results, options_mock)
+        self.assertEqual(
+            '1,1,1,0,1,"foo@100-100@FILENAME","FILENAME","foo","foo",'
+            '100,100,12.5,99.0',
+            sys.stdout.stream.splitlines()[0]
+        )
+
     def test_print_fileinfo(self):
         options_mock = Mock()
         options_mock.verbose = True


### PR DESCRIPTION
## Problem

`csv_output()` in `lizard_ext/csvoutput.py` only appended extension columns when an extension declared exactly one `FUNCTION_INFO` field:

```python
if hasattr(extension, 'FUNCTION_INFO') and \
        len(list(extension.FUNCTION_INFO)) == 1:
```

Any extension with more than one field was skipped entirely, so `lizard --csv -Eio` or `lizard --csv -Eduplicated_param_list` produced the same CSV as a run with no extension at all. The metrics appeared correctly in the default table but vanished in CSV output.

## Fix

Replace the `len == 1` guard with a plain loop over every `FUNCTION_INFO` key, accumulating `extension_variables` and `extension_captions` in declared order. The downstream header and row-building code is unchanged.

Single-field extensions (`-Eexitcount`, `-Egotocount`, etc.) and no-extension runs produce byte-for-byte identical output to before.

## Tests

Two regression tests added to `test/testOutputCSV.py`:

- `test_csv_header_with_multi_field_extension`: verifies the header contains all declared captions
- `test_csv_row_with_multi_field_extension`: verifies both field values appear in the data row

The tests use neutral field names (`metric_one`, `metric_two`) rather than real extension attribute names to avoid collisions with the `FunctionInfo` properties that extension modules install at import time.