### PR TITLE
feat: add option to disable .gitignore filtering

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,11 @@ Use .gitignore file:
 
     lizard mySource/
 
-If there is a .gitignore file in the given path, lizard will automatically use it as an additional filter to exclude files that match the gitignore patterns. This is useful when you want to analyze only the tracked files in your git repository.
+If there is a .gitignore file in the given path, lizard will automatically use it as an additional filter to exclude files that match the gitignore patterns. This is useful when you want to analyze only the tracked files in your git repository. To analyze all discovered source files regardless of .gitignore, use --no-gitignore:
+
+::
+
+    lizard --no-gitignore mySource/
 
 Options
 ~~~~~~~
@@ -159,6 +163,7 @@ Options
                         single character, "./folder/*" exclude everything in the folder
                         recursively. Multiple patterns can be specified. Don't forget to add ""
                         around the pattern.
+  --no-gitignore        Do not use .gitignore files to exclude files.
   -t WORKING_THREADS, --working_threads WORKING_THREADS
                         number of working threads. The default value is 1. Using a bigger number
                         can fully utilize the CPU and often faster.
@@ -400,4 +405,3 @@ Contributions are welcome. Please refer to the rules and development workflow in
 - https://github.com/terryyin/lizard/tree/master/.cursor/rules
 
 These guidelines are usable by both AI assistants and human contributors — what works for AI works for "I" as well — to keep changes cohesive, simple, and well-tested.
-

--- a/lizard.py
+++ b/lizard.py
@@ -78,13 +78,13 @@ DEFAULT_CCN_THRESHOLD, DEFAULT_WHITELIST, \
 
 # pylint: disable-msg=too-many-arguments
 def analyze(paths, exclude_pattern=None, threads=1, exts=None,
-            lans=None):
+            lans=None, use_gitignore=True):
     '''
     returns an iterator of file information that contains function
     statistics.
     '''
     exclude_pattern = exclude_pattern or []
-    files = get_all_source_files(paths, exclude_pattern, lans)
+    files = get_all_source_files(paths, exclude_pattern, lans, use_gitignore)
     return analyze_files(files, threads, exts)
 
 
@@ -210,6 +210,11 @@ def arg_parser(prog=None):
                         action="append",
                         dest="exclude",
                         default=[])
+    parser.add_argument("--no-gitignore",
+                        help='''Do not use .gitignore files to exclude files.''',
+                        action="store_false",
+                        dest="use_gitignore",
+                        default=True)
     parser.add_argument("-t", "--working_threads",
                         help='''number of working threads. The default
                         value is 1. Using a bigger
@@ -943,13 +948,14 @@ def md5_hash_file(full_path_name):
         return None
 
 
-def get_all_source_files(paths, exclude_patterns, lans):
+def get_all_source_files(paths, exclude_patterns, lans, use_gitignore=True):
     '''
     Function counts md5 hash for the given file and checks if it isn't a
     duplicate using set of hashes for previous files.
 
-    If a .gitignore file is found in any of the given paths, it will be used
-    to filter out files that match the gitignore patterns.
+    If use_gitignore is true and a .gitignore file is found in any of the
+    given paths, it will be used to filter out files that match the gitignore
+    patterns.
     '''
     hash_set = set()
     gitignore_spec = None
@@ -1005,7 +1011,8 @@ def get_all_source_files(paths, exclude_patterns, lans):
                     for filename in files:
                         yield os.path.join(root, filename)
 
-    _load_gitignore()
+    if use_gitignore:
+        _load_gitignore()
     return filter(_validate_file, all_listed_files(paths))
 
 
@@ -1126,7 +1133,8 @@ def main(argv=None):
         options.exclude,
         options.working_threads,
         options.extensions,
-        options.languages)
+        options.languages,
+        options.use_gitignore)
     warning_count = None
     if options.output_file:
         output_file = open_output_file(options.output_file)

--- a/test/testFilesFilter.py
+++ b/test/testFilesFilter.py
@@ -155,3 +155,46 @@ class TestFilesFilter(unittest.TestCase):
         else:
             file_names = ["./useful.cpp"]
         self.assertEqual(file_names, list(files))
+
+    @patch.object(os.path, "exists")
+    @patch.object(os.path, "relpath")
+    @patch.object(os, "walk")
+    @patch("lizard.auto_read")
+    @patch('lizard.md5_hash_file')
+    def test_gitignore_filter_can_be_disabled(self, md5, mock_auto_read,
+                                              mock_os_walk, mock_relpath,
+                                              mock_exists):
+        mock_os_walk.return_value = (['.',
+                                    None,
+                                    ['temp.c', 'node_modules/file.js', 'useful.cpp']], )
+        md5.side_effect = [1, 2, 3]
+        mock_exists.return_value = True
+        mock_relpath.side_effect = AssertionError(
+            "gitignore matching should not run")
+        mock_auto_read.side_effect = AssertionError(
+            ".gitignore should not be read")
+
+        files = get_all_source_files(["dir"], [], [], use_gitignore=False)
+        if which_system() == "Windows":
+            file_names = [".\\temp.c", ".\\node_modules/file.js", ".\\useful.cpp"]
+        else:
+            file_names = ["./temp.c", "./node_modules/file.js", "./useful.cpp"]
+        self.assertEqual(file_names, list(files))
+
+    @patch.object(os.path, "exists")
+    @patch.object(os, "walk")
+    @patch("lizard.auto_read")
+    def test_disabled_gitignore_does_not_parse_invalid_gitignore(self,
+                                                                 mock_auto_read,
+                                                                 mock_os_walk,
+                                                                 mock_exists):
+        mock_os_walk.return_value = (['.', None, ['useful.cpp']], )
+        mock_exists.return_value = True
+        mock_auto_read.return_value = "bin\\Debug\\\n"
+
+        files = get_all_source_files(["dir"], [], [], use_gitignore=False)
+        if which_system() == "Windows":
+            file_names = [".\\useful.cpp"]
+        else:
+            file_names = ["./useful.cpp"]
+        self.assertEqual(file_names, list(files))

--- a/test/test_options.py
+++ b/test/test_options.py
@@ -18,6 +18,14 @@ class TestOptionParsing(unittest.TestCase):
         options = parse_args(['lizard'])
         self.assertEqual(0, len(options.sorting))
 
+    def test_uses_gitignore_by_default(self):
+        options = parse_args(['lizard'])
+        self.assertTrue(options.use_gitignore)
+
+    def test_can_disable_gitignore(self):
+        options = parse_args(['lizard', '--no-gitignore'])
+        self.assertFalse(options.use_gitignore)
+
     def test_sorting_factor(self):
         options = parse_args(['lizard', '-snloc'])
         self.assertEqual("nloc", options.sorting[0])


### PR DESCRIPTION
When analyzing freshly cloned repositories, applying .gitignore is unnecessary because ignored files are not relevant to what Git checks out. It can also break analysis on Linux/Cloud Run when repositories contain Windows-style .gitignore patterns such as backslash paths.

Add --no-gitignore so callers can skip reading and parsing .gitignore files entirely, while preserving the existing default behavior.